### PR TITLE
feat: avoid error out on frame with invalid manufacturer code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,10 @@ fn parse_to_table(input: &str) -> std::string::String {
                     }) => {
                         table.add_row(row![
                             fixed_data_header.identification_number,
-                            fixed_data_header.manufacturer,
+                            fixed_data_header
+                                .manufacturer
+                                .map(|i| i.to_string())
+                                .unwrap_or_else(|_| "invalid".to_string()),
                             fixed_data_header.access_number,
                             fixed_data_header.status,
                             fixed_data_header.signature,

--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -58,7 +58,7 @@ impl<'a> DataInformationFieldExtensions<'a> {
     }
 }
 
-impl<'a> Iterator for DataInformationFieldExtensions<'a> {
+impl Iterator for DataInformationFieldExtensions<'_> {
     type Item = DataInformationFieldExtension;
     fn next(&mut self) -> Option<Self::Item> {
         let (head, tail) = self.0.split_first()?;
@@ -69,8 +69,8 @@ impl<'a> Iterator for DataInformationFieldExtensions<'a> {
         (self.0.len(), Some(self.0.len()))
     }
 }
-impl<'a> ExactSizeIterator for DataInformationFieldExtensions<'a> {}
-impl<'a> DoubleEndedIterator for DataInformationFieldExtensions<'a> {
+impl ExactSizeIterator for DataInformationFieldExtensions<'_> {}
+impl DoubleEndedIterator for DataInformationFieldExtensions<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let (end, start) = self.0.split_last()?;
         self.0 = start;

--- a/src/user_data/data_record.rs
+++ b/src/user_data/data_record.rs
@@ -73,7 +73,7 @@ impl<'a> TryFrom<&'a [u8]> for RawDataRecordHeader<'a> {
     }
 }
 
-impl<'a> TryFrom<&RawDataRecordHeader<'a>> for ProcessedDataRecordHeader {
+impl TryFrom<&RawDataRecordHeader<'_>> for ProcessedDataRecordHeader {
     type Error = DataRecordError;
     fn try_from(raw_data_record_header: &RawDataRecordHeader) -> Result<Self, DataRecordError> {
         let mut value_information = None;

--- a/src/user_data/mod.rs
+++ b/src/user_data/mod.rs
@@ -507,7 +507,7 @@ impl fmt::Display for Medium {
 #[derive(Debug, PartialEq)]
 pub struct FixedDataHeader {
     pub identification_number: IdentificationNumber,
-    pub manufacturer: ManufacturerCode,
+    pub manufacturer: Result<ManufacturerCode, ApplicationLayerError>,
     pub version: u8,
     pub medium: Medium,
     pub access_number: u8,
@@ -613,7 +613,7 @@ impl<'a> TryFrom<&'a [u8]> for UserDataBlock<'a> {
                         manufacturer: ManufacturerCode::from_id(u16::from_le_bytes([
                             *iter.next().ok_or(ApplicationLayerError::InsufficientData)?,
                             *iter.next().ok_or(ApplicationLayerError::InsufficientData)?,
-                        ]))?,
+                        ])),
                         version: *iter.next().ok_or(ApplicationLayerError::InsufficientData)?,
                         medium: MeasuredMedium::new(
                             *iter.next().ok_or(ApplicationLayerError::InsufficientData)?,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -138,18 +138,10 @@ mod tests {
                         .manufacturer
                         .unwrap()
                         .into_bytes();
-                    assert_eq!(
-                        fixed_data_header.manufacturer.code[0],
-                        expected_manufacturer[0] as char
-                    );
-                    assert_eq!(
-                        fixed_data_header.manufacturer.code[1],
-                        expected_manufacturer[1] as char
-                    );
-                    assert_eq!(
-                        fixed_data_header.manufacturer.code[2],
-                        expected_manufacturer[2] as char
-                    );
+                    let manufacturer = fixed_data_header.manufacturer.unwrap();
+                    assert_eq!(manufacturer.code[0], expected_manufacturer[0] as char);
+                    assert_eq!(manufacturer.code[1], expected_manufacturer[1] as char);
+                    assert_eq!(manufacturer.code[2], expected_manufacturer[2] as char);
                     assert_eq!(
                         fixed_data_header.access_number,
                         mbus_data.slave_information.access_number as u8


### PR DESCRIPTION
I am trying to move my project from pymeterbus and some heatmeters my project has to detect don't have filed out manufacturer code (it contains 0x00 bytes) with leads to m-bus-parser to error out and not be able to parse any DataRecords. I modified the code to not error out and be able to continue.
I suspect storing a `Result` inside a struct isn't the nicest option but this way the information that something happened while parsing the manufacturer code is still retained. I am open to other ideas how to handle that.
