### PR TITLE
feat: add lbs byte order support

### DIFF
--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -158,11 +158,8 @@ impl<'a> TryFrom<&'a [u8]> for Frame<'a> {
                 if *data.last().ok_or(FrameError::LengthShort)? != 0x16 {
                     return Err(FrameError::InvalidStopByte);
                 }
-
                 let control_field = *data.get(4).ok_or(FrameError::LengthShort)?;
-
                 let address_field = *data.get(5).ok_or(FrameError::LengthShort)?;
-
                 match control_field {
                     0x53 => Ok(Frame::ControlFrame {
                         function: Function::try_from(control_field)?,

--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -160,10 +160,8 @@ impl<'a> TryFrom<&'a [u8]> for Frame<'a> {
                 }
 
                 let control_field = *data.get(4).ok_or(FrameError::LengthShort)?;
-                println!("control_field: {:x?}", control_field);
 
                 let address_field = *data.get(5).ok_or(FrameError::LengthShort)?;
-                println!("address_field: {:x?}", address_field);
 
                 match control_field {
                     0x53 => Ok(Frame::ControlFrame {

--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -160,8 +160,11 @@ impl<'a> TryFrom<&'a [u8]> for Frame<'a> {
                 }
 
                 let control_field = *data.get(4).ok_or(FrameError::LengthShort)?;
+                println!("control_field: {:x?}", control_field);
 
                 let address_field = *data.get(5).ok_or(FrameError::LengthShort)?;
+                println!("address_field: {:x?}", address_field);
+
                 match control_field {
                     0x53 => Ok(Frame::ControlFrame {
                         function: Function::try_from(control_field)?,

--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -499,8 +499,6 @@ impl DataFieldCoding {
         input: &'a [u8],
         fixed_data_header: Option<&'a FixedDataHeader>,
     ) -> Result<Data<'a>, DataRecordError> {
-        println!("DataFieldCoding: {:?}", self);
-        println!("Input: {:x?}", input);
         let lsb_order = fixed_data_header.map(|x| x.lsb_order).unwrap_or(false);
 
         macro_rules! bcd_to_value {

--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -1,5 +1,6 @@
 use super::data_information::{self};
 use super::variable_user_data::DataRecordError;
+use super::FixedDataHeader;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug, PartialEq)]
@@ -457,6 +458,7 @@ fn bcd_to_value_internal(
     data: &[u8],
     num_digits: usize,
     sign: i32,
+    lsb_order: bool,
 ) -> Result<Data, DataRecordError> {
     if data.len() < (num_digits + 1) / 2 {
         return Err(DataRecordError::InsufficientData);
@@ -466,7 +468,12 @@ fn bcd_to_value_internal(
     let mut current_weight = 1.0;
 
     for i in 0..num_digits {
-        let byte = data.get(i / 2).ok_or(DataRecordError::InsufficientData)?;
+        let index = if lsb_order {
+            (num_digits - i - 1) / 2
+        } else {
+            i / 2
+        };
+        let byte = data.get(index).ok_or(DataRecordError::InsufficientData)?;
 
         let digit = if i % 2 == 0 {
             byte & 0x0F
@@ -487,14 +494,22 @@ fn bcd_to_value_internal(
 }
 
 impl DataFieldCoding {
-    pub fn parse<'a>(&self, input: &'a [u8]) -> Result<Data<'a>, DataRecordError> {
+    pub fn parse<'a>(
+        &self,
+        input: &'a [u8],
+        fixed_data_header: Option<&'a FixedDataHeader>,
+    ) -> Result<Data<'a>, DataRecordError> {
+        println!("DataFieldCoding: {:?}", self);
+        println!("Input: {:x?}", input);
+        let lsb_order = fixed_data_header.map(|x| x.lsb_order).unwrap_or(false);
+
         macro_rules! bcd_to_value {
             ($data:expr, $num_digits:expr) => {{
-                bcd_to_value_internal($data, $num_digits, 1)
+                bcd_to_value_internal($data, $num_digits, 1, lsb_order)
             }};
 
             ($data:expr, $num_digits:expr, $sign:expr) => {{
-                bcd_to_value_internal($data, $num_digits, $sign)
+                bcd_to_value_internal($data, $num_digits, $sign, lsb_order)
             }};
         }
 
@@ -875,7 +890,7 @@ mod tests {
     #[test]
     fn test_bcd_to_value_unsigned() {
         let data = [0x54, 0x76, 0x98];
-        let result = bcd_to_value_internal(&data, 6, 1);
+        let result = bcd_to_value_internal(&data, 6, 1, false);
         assert_eq!(
             result.unwrap(),
             Data {

--- a/src/user_data/data_record.rs
+++ b/src/user_data/data_record.rs
@@ -60,7 +60,7 @@ impl<'a> DataRecord<'a> {
                 )?;
             }
         }
-        println!("{:?}", data_out);
+
         Ok(DataRecord {
             data_record_header,
             data: data_out,

--- a/src/user_data/data_record.rs
+++ b/src/user_data/data_record.rs
@@ -2,6 +2,7 @@ use super::{
     data_information::{Data, DataFieldCoding, DataInformation, DataInformationBlock, DataType},
     value_information::{ValueInformation, ValueInformationBlock, ValueLabel},
     variable_user_data::DataRecordError,
+    FixedDataHeader,
 };
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug, PartialEq)]
@@ -26,6 +27,44 @@ impl DataRecord<'_> {
     #[must_use]
     pub fn get_size(&self) -> usize {
         self.data_record_header.get_size() + self.data.get_size()
+    }
+}
+
+impl<'a> DataRecord<'a> {
+    fn parse(
+        data: &'a [u8],
+        fixed_data_header: Option<&'a FixedDataHeader>,
+    ) -> Result<Self, DataRecordError> {
+        let data_record_header = DataRecordHeader::try_from(data)?;
+        let mut offset = data_record_header
+            .raw_data_record_header
+            .data_information_block
+            .get_size();
+        let mut data_out = Data {
+            value: Some(DataType::ManufacturerSpecific(data)),
+            size: data.len(),
+        };
+        if let Some(x) = &data_record_header
+            .raw_data_record_header
+            .value_information_block
+        {
+            offset += x.get_size();
+            if let Some(data_info) = &data_record_header
+                .processed_data_record_header
+                .data_information
+            {
+                data_out = data_info.data_field_coding.parse(
+                    data.get(offset..)
+                        .ok_or(DataRecordError::InsufficientData)?,
+                    fixed_data_header,
+                )?;
+            }
+        }
+        println!("{:?}", data_out);
+        Ok(DataRecord {
+            data_record_header,
+            data: data_out,
+        })
     }
 }
 
@@ -121,37 +160,19 @@ impl<'a> TryFrom<&'a [u8]> for DataRecordHeader<'a> {
     }
 }
 
+impl<'a> TryFrom<(&'a [u8], &'a FixedDataHeader)> for DataRecord<'a> {
+    type Error = DataRecordError;
+    fn try_from(
+        (data, fixed_data_header): (&'a [u8], &'a FixedDataHeader),
+    ) -> Result<Self, Self::Error> {
+        Self::parse(data, Some(fixed_data_header))
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for DataRecord<'a> {
     type Error = DataRecordError;
     fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
-        let data_record_header = DataRecordHeader::try_from(data)?;
-        let mut offset = data_record_header
-            .raw_data_record_header
-            .data_information_block
-            .get_size();
-        let mut data_out = Data {
-            value: Some(DataType::ManufacturerSpecific(data)),
-            size: data.len(),
-        };
-        if let Some(x) = &data_record_header
-            .raw_data_record_header
-            .value_information_block
-        {
-            offset += x.get_size();
-            if let Some(data_info) = &data_record_header
-                .processed_data_record_header
-                .data_information
-            {
-                data_out = data_info.data_field_coding.parse(
-                    data.get(offset..)
-                        .ok_or(DataRecordError::InsufficientData)?,
-                )?;
-            }
-        }
-        Ok(DataRecord {
-            data_record_header,
-            data: data_out,
-        })
+        Self::parse(data, None)
     }
 }
 

--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -1,5 +1,5 @@
 use super::data_information::{self};
-use super::DataRecords;
+use super::{DataRecords, FixedDataHeader};
 
 #[derive(Debug, PartialEq)]
 pub enum DataRecordError {
@@ -20,7 +20,13 @@ impl From<DataRecordError> for VariableUserDataError {
 
 impl<'a> From<&'a [u8]> for DataRecords<'a> {
     fn from(data: &'a [u8]) -> Self {
-        DataRecords::new(data)
+        DataRecords::new(data, None)
+    }
+}
+
+impl<'a> From<(&'a [u8], &'a FixedDataHeader)> for DataRecords<'a> {
+    fn from((data, fixed_data_header): (&'a [u8], &'a FixedDataHeader)) -> Self {
+        DataRecords::new(data, Some(fixed_data_header))
     }
 }
 


### PR DESCRIPTION
Some heatmeters use lsb byter order instead of msb. This affects how BCD should be decoded while reading identification number and any data records that are marked as BCD.
The bit indicating that the frame is lsb or msb is inside the control information part of the frame.
The test needs https://github.com/maebli/m-bus-parser/pull/27 to be able to pass.
The DataRecord api for decoding with lsb support isn't the best because it takes a tuple containing the record bytes and  FixedDataHeader, and to not break any previous code I did keep it to be able to take the record bytes only. I think in the future a struct that handles parsing the whole frame and handles such cases for the user might be preferable as now it is easy to forget to pass the FixedDataHeader and fallback to decode without checking for lsb byte order.