### PR TITLE
feat: more structs clone

### DIFF
--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -80,7 +80,7 @@ impl TryFrom<u8> for Function {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Address {
     Uninitalized,
     Primary(u8),

--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -25,7 +25,7 @@ pub enum Frame<'a> {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Function {
     SndNk,
     SndUd { fcb: bool },

--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -155,7 +155,7 @@ const MAXIMUM_DATA_INFORMATION_SIZE: usize = 11;
 #[derive(Debug, Clone, PartialEq)]
 pub struct DataInformationExtensionField {}
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DataInformationError {
     NoData,
     DataTooLong,

--- a/src/user_data/value_information.rs
+++ b/src/user_data/value_information.rs
@@ -881,7 +881,7 @@ impl fmt::Display for ValueInformation {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ValueLabel {
     Instantaneous,
     ReservedForObjectActions,

--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -1,7 +1,7 @@
 use super::data_information::{self};
 use super::{DataRecords, FixedDataHeader};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DataRecordError {
     DataInformationError(data_information::DataInformationError),
     InsufficientData,


### PR DESCRIPTION
Adds a lite bit of Clone derive to structs that I found I need it in the project that uses m-bus-parser.
I am unpacking stuff m-bus-parser creates into some my structs and in some cases I need to clone those