### PR TITLE
Make DataType cloneable

### DIFF
--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -3,7 +3,7 @@ use super::variable_user_data::DataRecordError;
 use super::FixedDataHeader;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataInformationBlock<'a> {
     pub data_information_field: DataInformationField,
@@ -21,7 +21,7 @@ impl DataInformationBlock<'_> {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataInformationField {
     pub data: u8,
@@ -285,7 +285,7 @@ impl From<TextUnit<'_>> for String {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Month {
     January,
@@ -329,7 +329,7 @@ pub type Minute = u8;
 pub type Second = u8;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SingleEveryOrInvalid<T> {
     Single(T),
@@ -338,7 +338,7 @@ pub enum SingleEveryOrInvalid<T> {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataType<'a> {
     Text(TextUnit<'a>),
@@ -371,7 +371,7 @@ pub enum DataType<'a> {
     ManufacturerSpecific(&'a [u8]),
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Data<'a> {
     pub value: Option<DataType<'a>>,

--- a/src/user_data/data_record.rs
+++ b/src/user_data/data_record.rs
@@ -5,21 +5,21 @@ use super::{
     FixedDataHeader,
 };
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RawDataRecordHeader<'a> {
     pub data_information_block: DataInformationBlock<'a>,
     pub value_information_block: Option<ValueInformationBlock>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ProcessedDataRecordHeader {
     pub data_information: Option<DataInformation>,
     pub value_information: Option<ValueInformation>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataRecord<'a> {
     pub data_record_header: DataRecordHeader<'a>,
@@ -72,7 +72,7 @@ impl<'a> DataRecord<'a> {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataRecordHeader<'a> {
     pub raw_data_record_header: RawDataRecordHeader<'a>,

--- a/src/user_data/value_information.rs
+++ b/src/user_data/value_information.rs
@@ -104,7 +104,7 @@ fn extract_plaintext_vife(data: &[u8]) -> Result<ArrayVec<char, 9>, DataInformat
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueInformationBlock {
     pub value_information: ValueInformationField,
@@ -113,7 +113,7 @@ pub struct ValueInformationBlock {
     pub plaintext_vife: Option<ArrayVec<char, 9>>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueInformationField {
     pub data: u8,
@@ -125,7 +125,7 @@ impl ValueInformationField {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueInformationFieldExtension {
     pub data: u8,
@@ -170,7 +170,7 @@ pub enum ValueInformationCoding {
     ManufacturerSpecific,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ValueInformationFieldExtensionCoding {
     MainVIFCodeExtension,
@@ -847,7 +847,7 @@ impl From<u8> for ValueInformationField {
 /// the whole information inside the value information block
 /// value(x) = (multiplier * value + offset) * units
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueInformation {
     pub decimal_offset_exponent: isize,


### PR DESCRIPTION
Not sure if this is one that goes against the design philosophy of this crate, but something we are struggling with is getting data out of the `DataType` type. 

When we parse our mbus frames with 

```
let mbus_data = MbusData::try_from(bytes.as_slice())?
```

the data we pull out of `mbus_data` via the `data.value` fields to get `DataType` has the same lifetime of the `bytes` variable. We call this function inside of a function called `decode` and want to return `Datatype` from this function, but we can't because its lifetime is tied to the lifetime of `bytes`. 

We've tried returning `bytes` and moving ownership of `bytes` and the `DataType` result into their own data structure and returning that, but those options didn't work.

One solution, I think, would be to allow Cloning of the `DataType` type, allowing us to return it from our `decode` function - which is what this PR attempts to achieve. 

Let me know if there is another way of doing this or if you need more information. 