### PR TITLE
Extend Variable Length Data parsing

### DIFF
--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -32,7 +32,61 @@ impl<'a> From<(&'a [u8], &'a FixedDataHeader)> for DataRecords<'a> {
     }
 }
 
+#[cfg(all(test, feature = "std"))]
 mod tests {
+    use crate::user_data::{data_information::DataFieldCoding, data_record::DataRecord};
+
+    #[test]
+    fn test_parse_variable_data_length() {
+        use crate::user_data::data_information::DataFieldCoding;
+        use crate::user_data::data_information::DataType;
+        use crate::user_data::data_information::TextUnit;
+        use crate::user_data::DataRecords;
+
+        let data: &[u8] = &[
+            0x0D, 0x06, 0xC1, 0x12, 0x0D, 0x06, 0xD3, 0x12, 0x34, 0x56, 0x0D, 0x06, 0x02, 0x31,
+            0x32, 0x0D, 0x06, 0xE1, 0xFF, 0x0D, 0x06, 0x00,
+        ];
+
+        let records: Vec<DataRecord<'_>> = DataRecords::from(data).flatten().collect();
+
+        assert_eq!(records.len(), 5);
+        {
+            let record = records.get(0).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Number(12.0))
+        }
+        {
+            let record = records.get(1).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Number(-563412.0))
+        }
+        {
+            let record = records.get(2).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[0x31, 0x32])))
+        }
+        {
+            let record = records.get(3).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Number(-1.0))
+        }
+        {
+            let record = records.get(4).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+    }
 
     #[test]
     fn test_parse_variable_data() {
@@ -81,5 +135,15 @@ mod tests {
     const fn _test_parse_variable_data3() {
         /* Data block 3: unit 1, storage No 0, tariff 2, instantaneous energy, 218,37 kWh (6 digit BCD) */
         let _data = &[0x8B, 0x60, 0x04, 0x37, 0x18, 0x02];
+    }
+
+    fn get_data_field_coding(record: &DataRecord) -> DataFieldCoding {
+        record
+            .data_record_header
+            .processed_data_record_header
+            .data_information
+            .clone()
+            .unwrap()
+            .data_field_coding
     }
 }


### PR DESCRIPTION
Extended/adjusted the support for Variable Length Data Coding.

Separated out C0..C9 and D0..D9 range as the length of the data is dependant on subtracting the base case (C0 or D0).
Accounted for the 0 length cases by changing `1..length` to `1..(1+length)`.
Extended the size of Data to include the byte which indicates the length of the data.

I've left the 64 -> 256 bit number decoding for now. I'm unsure how best to approach that as we store all Numbers as f64 currently.

Added tests to cover the variable data cases amended. I did them all in a single test to make sure that the offset tracking was working as expected. If the tracking was incorrect, each subsequent Data block would be misaligned and incorrect.

As always, let me know if there's any issues.