### PR TITLE
LossyNumber

### DIFF
--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -343,6 +343,7 @@ pub enum SingleEveryOrInvalid<T> {
 pub enum DataType<'a> {
     Text(TextUnit<'a>),
     Number(f64),
+    LossyNumber(f64),
     Date(
         SingleEveryOrInvalid<DayOfMonth>,
         SingleEveryOrInvalid<Month>,
@@ -395,6 +396,7 @@ impl std::fmt::Display for Data<'_> {
         match &self.value {
             Some(value) => match value {
                 DataType::Number(value) => write!(f, "{}", value),
+                DataType::LossyNumber(value) => write!(f, "{}", value),
                 DataType::Date(day, month, year) => write!(f, "{}/{}/{}", day, month, year),
                 DataType::DateTime(day, month, year, hour, minute) => {
                     write!(f, "{}/{}/{} {}:{}:00", day, month, year, hour, minute)
@@ -531,6 +533,27 @@ fn integer_to_value_internal(data: &[u8], byte_size: usize) -> Data<'_> {
     }
 }
 
+fn integer_to_value_lossy_internal(data: &[u8], byte_size: usize) -> Data<'_> {
+    let mut data_value = 0i64;
+    let mut shift = 0;
+
+    for byte in data.iter().take(if byte_size > 8 { 8 } else { byte_size }) {
+        data_value |= (*byte as i64) << shift;
+        shift += 8;
+    }
+
+    let msb = (data_value >> (shift - 1)) & 1;
+    let data_value = if byte_size < 8 && msb == 1 {
+        -((data_value ^ (2i64.pow(shift) - 1)) + 1)
+    } else {
+        data_value
+    };
+    Data {
+        value: Some(DataType::LossyNumber(data_value as f64)),
+        size: byte_size,
+    }
+}
+
 impl DataFieldCoding {
     pub fn parse<'a>(
         &self,
@@ -554,7 +577,11 @@ impl DataFieldCoding {
                 if $data.len() < $byte_size {
                     return Err(DataRecordError::InsufficientData);
                 }
-                Ok(integer_to_value_internal($data, $byte_size))
+                if $byte_size > 8 {
+                    Ok(integer_to_value_lossy_internal($data, $byte_size))
+                } else {
+                    Ok(integer_to_value_internal($data, $byte_size))
+                }
             }};
         }
         match self {
@@ -651,16 +678,40 @@ impl DataFieldCoding {
                     }
                     0xF0..=0xF4 => {
                         length -= 0xEC;
-                        // integer_to_value!(input, 4 * length as usize)
-                        todo!("Variable length handle 64 -> 128 bit numbers: {}", length);
+                        let bytes = input
+                            .get(1..(1 + 4 * length as usize))
+                            .ok_or(DataRecordError::InsufficientData)?;
+                        match integer_to_value!(bytes, 4 * length as usize) {
+                            Ok(data) => Ok(Data {
+                                value: data.value,
+                                size: data.size + 1,
+                            }),
+                            Err(err) => Err(err),
+                        }
                     }
                     0xF5 => {
-                        // integer_to_value!(input, 48)
-                        todo!("Variable length handle 192 bit number: {}", length);
+                        let bytes = input
+                            .get(1..(1 + 48_usize))
+                            .ok_or(DataRecordError::InsufficientData)?;
+                        match integer_to_value!(bytes, 48_usize) {
+                            Ok(data) => Ok(Data {
+                                value: data.value,
+                                size: data.size + 1,
+                            }),
+                            Err(err) => Err(err),
+                        }
                     }
                     0xF6 => {
-                        // integer_to_value!(input, 64)
-                        todo!("Variable length handle 256 bit number: {}", length);
+                        let bytes = input
+                            .get(1..(1 + 64_usize))
+                            .ok_or(DataRecordError::InsufficientData)?;
+                        match integer_to_value!(bytes, 64_usize) {
+                            Ok(data) => Ok(Data {
+                                value: data.value,
+                                size: data.size + 1,
+                            }),
+                            Err(err) => Err(err),
+                        }
                     }
                     _ => {
                         todo!(

--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -89,6 +89,106 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_variable_lossy_data_length() {
+        use crate::user_data::data_information::DataFieldCoding;
+        use crate::user_data::data_information::DataType;
+        use crate::user_data::data_information::TextUnit;
+        use crate::user_data::DataRecords;
+
+        let data: &[u8] = &[
+            0x0D, 0x06, 0xE9, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0D, 0x06,
+            0x00, 0x0D, 0x06, 0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0D, 0x06, 0x00, 0x0D, 0x06, 0xF4, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0x0D, 0x06, 0x00, 0x0D, 0x06, 0xF5, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0D,
+            0x06, 0x00, 0x0D, 0x06, 0xF6, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0D,
+            0x06, 0x00,
+        ];
+
+        let records: Vec<DataRecord<'_>> = DataRecords::from(data).flatten().collect();
+
+        assert_eq!(records.len(), 10);
+        {
+            let record = records.get(0).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::LossyNumber(-1.0))
+        }
+        {
+            let record = records.get(1).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+        {
+            let record = records.get(2).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::LossyNumber(-1.0))
+        }
+        {
+            let record = records.get(3).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+        {
+            let record = records.get(4).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::LossyNumber(-1.0))
+        }
+        {
+            let record = records.get(5).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+        {
+            let record = records.get(6).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::LossyNumber(-1.0))
+        }
+        {
+            let record = records.get(7).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+        {
+            let record = records.get(8).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::LossyNumber(-1.0))
+        }
+        {
+            let record = records.get(9).unwrap();
+            let code = get_data_field_coding(record);
+            assert_eq!(code, DataFieldCoding::VariableLength);
+            let value = record.data.value.clone().unwrap();
+            assert_eq!(value, DataType::Text(TextUnit::new(&[])))
+        }
+    }
+
+    #[test]
     fn test_parse_variable_data() {
         use crate::user_data::DataRecords;
 


### PR DESCRIPTION
Added the LossyNumber DataType as discussed.

The variable data length covered is from 64 bits all the way to 512 bits (64 bytes). 

There is no way to accurately store up to 512 bits in just 64 so it just takes the 64 least significant bits and stores them in an f64 as we do with anything 64 bit and smaller.

Added tests for each variable data length accounted for. Used 0-length variable data between each DataRecord to ensure that length of the variable data was accounted for correctly.