### PR TITLE
Fix DataRecords iterator error handling

### DIFF
--- a/src/user_data/mod.rs
+++ b/src/user_data/mod.rs
@@ -51,11 +51,15 @@ impl<'a> Iterator for DataRecords<'a> {
                     } else {
                         DataRecord::try_from(self.data.get(self.offset..)?)
                     };
-                    if let Ok(record) = record {
-                        self.offset += record.get_size();
-                        return Some(Ok(record));
-                    } else {
-                        self.offset = self.data.len();
+                    match record {
+                        Ok(record) => {
+                            self.offset += record.get_size();
+                            return Some(Ok(record));
+                        }
+                        Err(err) => {
+                            self.offset = self.data.len();
+                            return Some(Err(err));
+                        }
                     }
                 }
             }

--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -32,6 +32,22 @@ impl<'a> From<(&'a [u8], &'a FixedDataHeader)> for DataRecords<'a> {
     }
 }
 
+impl<'a> TryFrom<&'a [u8]> for DataRecords<'a> {
+    type Error = VariableUserDataError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        Ok(Self::from(data))
+    }
+}
+
+impl<'a> TryFrom<(&'a [u8], &'a FixedDataHeader)> for DataRecords<'a> {
+    type Error = VariableUserDataError;
+
+    fn try_from((data, fixed_data_header): (&'a [u8], &'a FixedDataHeader)) -> Result<Self, Self::Error> {
+        Ok(Self::from((data, fixed_data_header)))
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use crate::user_data::{data_information::DataFieldCoding, data_record::DataRecord};


### PR DESCRIPTION
## Summary
- implement missing error propagation in `DataRecords::next`

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68409e1f8bd48328815ab74def0ba2a7