### PR TITLE
Update publish-wasm workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,10 +142,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     if: startsWith(github.ref, 'refs/tags/wasm-v')
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -169,8 +172,23 @@ jobs:
           npm install
           npm ci
       - name: Publish to npm
-        run: | 
+        run: |
           cd wasm/pkg
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Copy wasm artifacts to docs
+        run: |
+          cp wasm/pkg/m_bus_parser_wasm_pack.js docs/
+          cp wasm/pkg/m_bus_parser_wasm_pack_bg.js docs/
+          cp wasm/pkg/m_bus_parser_wasm_pack_bg.wasm docs/
+          cp wasm/pkg/package.json docs/
+      - name: Commit updated wasm artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add docs/m_bus_parser_wasm_pack.js docs/m_bus_parser_wasm_pack_bg.js docs/m_bus_parser_wasm_pack_bg.wasm docs/meter.png docs/package.json
+          git commit -m "Update docs wasm artifacts" || echo "No changes to commit"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary
- allow publish-wasm to commit built files
- copy wasm pkg files to docs and push

## Testing
- `cargo fmt --all -- --check`
- `cargo test --verbose`
- `cargo test --verbose -F std`
- `cargo test --verbose -F plaintext-before-extension`
- `rustup component add clippy`
- `cargo clippy -- -D warnings`
- `cd cli && cargo fmt -- --check && cargo build --verbose && cargo test --verbose && cargo clippy -- -D warnings`
- `cd wasm && cargo fmt -- --check && cargo build --verbose && cargo test --verbose && cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684eaace77bc83288c25e8a1270fd6d7