### PR TITLE
Apply API guidelines

### DIFF
--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -3,6 +3,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Frame<'a> {
     SingleCharacter {
         character: u8,
@@ -28,6 +29,7 @@ pub enum Frame<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Function {
     SndNk,
     SndUd { fcb: bool },
@@ -84,6 +86,7 @@ impl TryFrom<u8> for Function {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Address {
     Uninitalized,
     Primary(u8),
@@ -121,9 +124,10 @@ impl Address {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum FrameError {
     EmptyData,
     InvalidStartByte,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,10 @@
 //! # Example
 //! ```rust
 //! use m_bus_parser::frames::{ Address, Frame, Function };
-//! use m_bus_parser::user_data::{ DataRecords, UserDataBlock };
+//! use m_bus_parser::user_data::{DataRecords, UserDataBlock};
 //! use m_bus_parser::mbus_data::MbusData;
-//! use std::io;
 //!
+//! fn try_parse() -> Result<(), m_bus_parser::MbusError> {
 //!     let example = vec![
 //!         0x68, 0x4D, 0x4D, 0x68, 0x08, 0x01, 0x72, 0x01,
 //!         0x00, 0x00, 0x00, 0x96, 0x15, 0x01, 0x00, 0x18,
@@ -24,22 +24,22 @@
 //!     ];
 //!
 //!     // Parse the frame
-//!     let frame = Frame::try_from(example.as_slice()).unwrap();
+//!     let frame = Frame::try_from(example.as_slice())?;
 //!
 //!     if let Frame::LongFrame { function, address, data } = frame {
 //!         assert_eq!(function, Function::RspUd { acd: false, dfc: false });
 //!         assert_eq!(address, Address::Primary(1));
 //!         if let Ok(UserDataBlock::VariableDataStructure { fixed_data_header, variable_data_block }) = UserDataBlock::try_from(data) {
-//!             let data_records = DataRecords::try_from(variable_data_block).unwrap();
-//!             println!("data_records: {:#?}", data_records);
-//!             let data_records = DataRecords::try_from(variable_data_block).unwrap();
+//!             let data_records = DataRecords::from((variable_data_block, &fixed_data_header));
+//!             println!("data_records: {:#?}", data_records.collect::<Result<Vec<_>, _>>()?);
 //!         }
 //!     }
 //!
 //!     // Parse everything at once
-//!     let parsed_data = m_bus_parser::mbus_data::MbusData::try_from(example.as_slice()).unwrap();
+//!     let parsed_data = MbusData::try_from(example.as_slice())?;
 //!     println!("parsed_data: {:#?}", parsed_data);
-//!
+//!     Ok(())
+//! }
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -54,12 +54,28 @@ pub mod user_data;
 #[cfg(feature = "std")]
 pub use mbus_data::serialize_mbus_data;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
 pub enum MbusError {
     FrameError(FrameError),
     ApplicationLayerError(ApplicationLayerError),
+    DataRecordError(user_data::variable_user_data::DataRecordError),
 }
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for MbusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MbusError::FrameError(e) => write!(f, "{}", e),
+            MbusError::ApplicationLayerError(e) => write!(f, "{}", e),
+            MbusError::DataRecordError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MbusError {}
 
 impl From<FrameError> for MbusError {
     fn from(error: FrameError) -> Self {
@@ -70,5 +86,11 @@ impl From<FrameError> for MbusError {
 impl From<ApplicationLayerError> for MbusError {
     fn from(error: ApplicationLayerError) -> Self {
         Self::ApplicationLayerError(error)
+    }
+}
+
+impl From<user_data::variable_user_data::DataRecordError> for MbusError {
+    fn from(error: user_data::variable_user_data::DataRecordError) -> Self {
+        Self::DataRecordError(error)
     }
 }

--- a/src/mbus_data.rs
+++ b/src/mbus_data.rs
@@ -67,6 +67,7 @@ fn clean_and_convert(input: &str) -> Vec<u8> {
 }
 
 #[cfg(feature = "std")]
+#[must_use]
 pub fn serialize_mbus_data(data: &str, format: &str) -> String {
     match format {
         "json" => parse_to_json(data),
@@ -77,6 +78,7 @@ pub fn serialize_mbus_data(data: &str, format: &str) -> String {
 }
 
 #[cfg(feature = "std")]
+#[must_use]
 pub fn parse_to_json(input: &str) -> String {
     let data = clean_and_convert(input);
     let parsed_data = MbusData::try_from(data.as_slice());
@@ -87,6 +89,7 @@ pub fn parse_to_json(input: &str) -> String {
 }
 
 #[cfg(feature = "std")]
+#[must_use]
 fn parse_to_yaml(input: &str) -> String {
     let data = clean_and_convert(input);
     let parsed_data = MbusData::try_from(data.as_slice());
@@ -97,6 +100,7 @@ fn parse_to_yaml(input: &str) -> String {
 }
 
 #[cfg(feature = "std")]
+#[must_use]
 fn parse_to_table(input: &str) -> String {
     use user_data::UserDataBlock;
 
@@ -196,6 +200,7 @@ fn parse_to_table(input: &str) -> String {
 }
 
 #[cfg(feature = "std")]
+#[must_use]
 pub fn parse_to_csv(input: &str) -> String {
     use crate::user_data::UserDataBlock;
     use prettytable::csv;

--- a/src/user_data/data_information.rs
+++ b/src/user_data/data_information.rs
@@ -162,14 +162,33 @@ const MAXIMUM_DATA_INFORMATION_SIZE: usize = 11;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DataInformationExtensionField {}
 
-#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum DataInformationError {
     NoData,
     DataTooLong,
     DataTooShort,
     InvalidValueInformation,
 }
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for DataInformationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataInformationError::NoData => write!(f, "No data available"),
+            DataInformationError::DataTooLong => write!(f, "Data too long"),
+            DataInformationError::DataTooShort => write!(f, "Data too short"),
+            DataInformationError::InvalidValueInformation => {
+                write!(f, "Invalid value information")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DataInformationError {}
 
 impl TryFrom<&DataInformationBlock<'_>> for DataInformation {
     type Error = DataInformationError;
@@ -256,6 +275,7 @@ impl TryFrom<&DataInformationBlock<'_>> for DataInformation {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TextUnit<'a>(&'a [u8]);
 impl<'a> TextUnit<'a> {
+    #[must_use]
     pub const fn new(input: &'a [u8]) -> Self {
         Self(input)
     }
@@ -285,8 +305,9 @@ impl From<TextUnit<'_>> for String {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Month {
     January,
     February,
@@ -331,6 +352,7 @@ pub type Second = u8;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum SingleEveryOrInvalid<T> {
     Single(T),
     Every(),
@@ -340,6 +362,7 @@ pub enum SingleEveryOrInvalid<T> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum DataType<'a> {
     Text(TextUnit<'a>),
     Number(f64),
@@ -828,6 +851,7 @@ impl DataInformation {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum FunctionField {
     InstantaneousValue,
     MaximumValue,
@@ -849,6 +873,7 @@ impl std::fmt::Display for FunctionField {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum SpecialFunctions {
     ManufacturerSpecific,
     MoreRecordsFollow,
@@ -866,6 +891,7 @@ pub struct Value {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum DataFieldCoding {
     NoData,
     Integer8Bit,

--- a/src/user_data/mod.rs
+++ b/src/user_data/mod.rs
@@ -133,8 +133,9 @@ impl fmt::Display for StatusField {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Direction {
     SlaveToMaster,
     MasterToSlave,
@@ -172,8 +173,9 @@ impl From<ControlInformation> for Direction {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ControlInformation {
     SendData,
     SelectSlave,
@@ -231,9 +233,10 @@ impl ControlInformation {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ApplicationLayerError {
     MissingControlInformation,
     InvalidControlInformation { byte: u8 },
@@ -273,8 +276,9 @@ impl fmt::Display for ApplicationLayerError {
 impl std::error::Error for ApplicationLayerError {}
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ApplicationResetSubcode {
     All(u8),
     UserData(u8),
@@ -421,6 +425,7 @@ pub struct FixedDataHeder {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum UserDataBlock<'a> {
     ResetAtApplicationLevel {
         subcode: ApplicationResetSubcode,
@@ -440,8 +445,9 @@ pub enum UserDataBlock<'a> {
     },
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum Medium {
     Other,
     Oil,

--- a/src/user_data/value_information.rs
+++ b/src/user_data/value_information.rs
@@ -160,8 +160,9 @@ impl ValueInformationFieldExtension {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ValueInformationCoding {
     Primary,
     PlainText,
@@ -170,8 +171,9 @@ pub enum ValueInformationCoding {
     ManufacturerSpecific,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ValueInformationFieldExtensionCoding {
     MainVIFCodeExtension,
     AlternateVIFCodeExtension,
@@ -832,8 +834,9 @@ fn consume_orthhogonal_vife(
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ValueInformationError {
     InvalidValueInformation,
 }
@@ -889,8 +892,9 @@ impl fmt::Display for ValueInformation {
     }
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ValueLabel {
     Instantaneous,
     ReservedForObjectActions,
@@ -1095,6 +1099,7 @@ impl fmt::Display for Unit {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum UnitName {
     Watt,
     ReactiveWatt,

--- a/src/user_data/variable_user_data.rs
+++ b/src/user_data/variable_user_data.rs
@@ -1,18 +1,47 @@
 use super::data_information::{self};
 use super::{DataRecords, FixedDataHeader};
 
-#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum DataRecordError {
     DataInformationError(data_information::DataInformationError),
     InsufficientData,
 }
 
-#[derive(Debug, PartialEq)]
+#[cfg(feature = "std")]
+impl std::fmt::Display for DataRecordError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataRecordError::DataInformationError(e) => write!(f, "{}", e),
+            DataRecordError::InsufficientData => write!(f, "Insufficient data"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DataRecordError {}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum VariableUserDataError {
     DataInformationError(DataRecordError),
 }
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for VariableUserDataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariableUserDataError::DataInformationError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VariableUserDataError {}
 
 impl From<DataRecordError> for VariableUserDataError {
     fn from(error: DataRecordError) -> Self {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -86,6 +86,7 @@ fn medium_to_str(medium: Medium) -> &'static str {
         Medium::DualWater => "DualWater",
         Medium::Pressure => "Pressure",
         Medium::ADConverter => "ADConverter",
+        _ => unreachable!(),
     }
 }
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- mark errors as `Clone`/`Copy`
- implement `Display`/`Error` for more error types
- expose data record errors through `MbusError`
- update crate docs to use `?` in examples

## Testing
- `cargo test --quiet`
- `cargo test --quiet -F std`
- `cargo test --quiet -F plaintext-before-extension`
- `cargo clippy -- -D warnings`
- `cd cli && cargo fmt -- --check && cargo build --quiet && cargo test --quiet && cargo clippy --quiet -- -D warnings`
- `cd wasm && cargo fmt -- --check && cargo build --quiet && cargo test --quiet && cargo clippy --quiet -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684b35c51da48328836b432a2c9b67d7