### PR TITLE
Make JSON/YAML output idiomatic with structured record values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
+Breaking changes for JSON/YAML consumers:
+
+- Changed `summary.records[].value` from a table-style string (e.g.
+  `"(2850427)e-2[m³](Volume)"`) to structured fields: `value` (number),
+  `exponent`, `unit` and `quantity`, derived from the processed data record
+  header. The human-readable string is still available as
+  `summary.records[].display`. Table and CSV outputs are unchanged.
+- Removed the top-level `manufacturer_info` key from JSON and YAML output.
+  Migration: use `summary.manufacturer`, which carries `code`, `name`,
+  `website` and `description`.
+- Changed raw byte payloads (`frame.data` of wireless frames,
+  `data_records[].raw_bytes` and manufacturer-specific record data) to
+  serialize as compact uppercase hex strings instead of decimal byte arrays.
+  Migration: decode the hex string instead of reading a JSON/YAML array
+  (e.g. `"2F2F"` instead of `[47, 47]`). Serialize-only: parsing APIs and
+  `Deserialize` implementations are unchanged.
+
 ## [0.1.4] - 2026-07-17
 
 - Added direct application-layer parsing APIs, record accessors, and a crate-local data-record example.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "A library for parsing M-Bus frames"
 license = "MIT"
@@ -47,10 +47,10 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 bitflags = "2.8.0"
 arrayvec = { version = "0.7.4", default-features = false }
 defmt = { version = "1.0.1", optional = true }
-wired-mbus-link-layer = { version = "0.1.4", path = "crates/wired-mbus-link-layer" }
-wireless-mbus-link-layer = { version = "0.1.4", path = "crates/wireless-mbus-link-layer" }
-m-bus-core = { version = "0.1.4", path = "crates/m-bus-core" }
-m-bus-application-layer = { version = "0.1.4", path = "crates/m-bus-application-layer" }
+wired-mbus-link-layer = { version = "0.2.0", path = "crates/wired-mbus-link-layer" }
+wireless-mbus-link-layer = { version = "0.2.0", path = "crates/wireless-mbus-link-layer" }
+m-bus-core = { version = "0.2.0", path = "crates/m-bus-core" }
+m-bus-application-layer = { version = "0.2.0", path = "crates/m-bus-application-layer" }
 aes = { version = "0.9", optional = true, default-features = false }
 cbc = { version = "0.2", optional = true, default-features = false }
 cipher = { version = "0.5", optional = true, default-features = false, features = ["block-padding"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser-cli"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "A cli to use the library for parsing M-Bus frames"
 license = "MIT"
@@ -22,6 +22,6 @@ default = ["decryption"]
 decryption = ["m-bus-parser/decryption"]
 
 [dependencies]
-m-bus-parser = { path = "..", version = "0.1.4", features = ["std", "serde"] }
+m-bus-parser = { path = "..", version = "0.2.0", features = ["std", "serde"] }
 hex = "0.4"
 clap = { version = "4.5.4", features = ["derive"] }

--- a/crates/m-bus-application-layer/Cargo.toml
+++ b/crates/m-bus-application-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-application-layer"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "M-Bus application layer parser (DIF/VIF, data records)"
 license = "MIT"
@@ -20,4 +20,4 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 defmt = { version = "1.0.1", optional = true }
 bitflags = "2.8.0"
 arrayvec = { version = "0.7.4", default-features = false }
-m-bus-core = { version = "0.1.4", path = "../m-bus-core" }
+m-bus-core = { version = "0.2.0", path = "../m-bus-core" }

--- a/crates/m-bus-application-layer/src/data_information.rs
+++ b/crates/m-bus-application-layer/src/data_information.rs
@@ -400,7 +400,13 @@ pub enum DataType<'a> {
         SingleEveryOrInvalid<Minute>,
         SingleEveryOrInvalid<Second>,
     ),
-    ManufacturerSpecific(&'a [u8]),
+    ManufacturerSpecific(
+        #[cfg_attr(
+            feature = "serde",
+            serde(serialize_with = "m_bus_core::serde_hex::serialize")
+        )]
+        &'a [u8],
+    ),
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(PartialEq, Debug, Clone)]

--- a/crates/m-bus-application-layer/src/data_record.rs
+++ b/crates/m-bus-application-layer/src/data_record.rs
@@ -25,6 +25,10 @@ pub struct DataRecord<'a> {
     pub data_record_header: DataRecordHeader<'a>,
     pub data: Data<'a>,
     /// Raw bytes encompassing this data record
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "m_bus_core::serde_hex::serialize")
+    )]
     pub raw_bytes: &'a [u8],
 }
 

--- a/crates/m-bus-core/Cargo.toml
+++ b/crates/m-bus-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-core"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 description = "Core types for the m-bus-parser M-Bus protocol library"
 license = "MIT"

--- a/crates/m-bus-core/src/lib.rs
+++ b/crates/m-bus-core/src/lib.rs
@@ -1,5 +1,28 @@
 pub mod decryption;
 
+/// Serializes raw byte payloads as compact uppercase hex strings so that
+/// human-facing dumps (JSON/YAML) don't render them as decimal byte arrays.
+/// Serialize-only: deserialization of these fields is unaffected.
+#[cfg(feature = "serde")]
+pub mod serde_hex {
+    use core::fmt;
+
+    struct HexSlice<'a>(&'a [u8]);
+
+    impl fmt::Display for HexSlice<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            for byte in self.0 {
+                write!(f, "{:02X}", byte)?;
+            }
+            Ok(())
+        }
+    }
+
+    pub fn serialize<S: serde::Serializer>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(&HexSlice(data))
+    }
+}
+
 #[cfg(feature = "std")]
 use std::fmt::{self, Display};
 

--- a/crates/wired-mbus-link-layer/Cargo.toml
+++ b/crates/wired-mbus-link-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wired-mbus-link-layer"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 description = "Wired M-Bus link layer parser (EN 13757-2)"
 license = "MIT"
@@ -15,4 +15,4 @@ defmt = ["dep:defmt"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 defmt = { version = "1.0.1", optional = true }
-m-bus-core = { version = "0.1.4", path = "../m-bus-core" }
+m-bus-core = { version = "0.2.0", path = "../m-bus-core" }

--- a/crates/wireless-mbus-link-layer/Cargo.toml
+++ b/crates/wireless-mbus-link-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireless-mbus-link-layer"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 description = "Wireless M-Bus link layer parser (wMBus)"
 license = "MIT"
@@ -14,6 +14,6 @@ defmt = ["dep:defmt"]
 
 [dependencies]
 crc16 = "0.4.0"
-m-bus-core = { version = "0.1.4", path = "../m-bus-core" }
+m-bus-core = { version = "0.2.0", path = "../m-bus-core" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 defmt = { version = "1.0.1", optional = true }

--- a/crates/wireless-mbus-link-layer/src/lib.rs
+++ b/crates/wireless-mbus-link-layer/src/lib.rs
@@ -96,6 +96,10 @@ pub fn strip_format_a_crcs<'a>(data: &[u8], output: &'a mut [u8]) -> Option<&'a 
 pub struct WirelessFrame<'a> {
     pub function: Function,
     pub manufacturer_id: ManufacturerId,
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "m_bus_core::serde_hex::serialize")
+    )]
     pub data: &'a [u8],
 }
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymbusparser"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://maebli.github.io/"
 repository = "https://github.com/maebli/m-bus-parser"
@@ -8,7 +8,7 @@ description = "A Python binding for the M-Bus parser"
 license = "MIT"
 
 [dependencies]
-m-bus-parser = { path = "..", version = "0.1.4", features = ["std", "serde", "decryption"] }
+m-bus-parser = { path = "..", version = "0.2.0", features = ["std", "serde", "decryption"] }
 serde_json = "1.0"
 pyo3 = { version = "0.29.0", features = ["extension-module", "generate-import-lib"] }
 hex = "0.4"

--- a/src/mbus_data.rs
+++ b/src/mbus_data.rs
@@ -187,7 +187,16 @@ struct ManufacturerSummary {
 #[cfg(feature = "std")]
 #[derive(serde::Serialize)]
 struct RecordSummary {
-    value: String,
+    /// Human-readable rendering (same string the table and CSV outputs use).
+    display: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exponent: Option<isize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quantity: Option<String>,
     data_information: String,
     header_hex: String,
     data_hex: String,
@@ -280,16 +289,19 @@ fn variable_data_block<'a>(user_data: Option<&user_data::UserDataBlock<'a>>) -> 
 
 #[cfg(feature = "std")]
 fn record_summaries(records: &user_data::DataRecords) -> Vec<RecordSummary> {
+    use user_data::data_information::DataType;
+
     records
         .clone()
         .flatten()
         .map(|record| {
-            let value_information = match record
+            let value_information = record
                 .data_record_header
                 .processed_data_record_header
                 .value_information
-            {
-                Some(ref x) => format!("{}", x),
+                .as_ref();
+            let value_information_display = match value_information {
+                Some(x) => format!("{}", x),
                 None => ")".to_string(),
             };
             let data_information = match record
@@ -300,8 +312,28 @@ fn record_summaries(records: &user_data::DataRecords) -> Vec<RecordSummary> {
                 Some(ref x) => format!("{}", x),
                 None => "None".to_string(),
             };
+            let value = match record.data.value {
+                Some(DataType::Number(n)) | Some(DataType::LossyNumber(n)) => Some(n),
+                _ => None,
+            };
+            let unit = value_information
+                .map(|vi| vi.units.iter().map(ToString::to_string).collect::<String>())
+                .filter(|s| !s.is_empty());
+            let quantity = value_information
+                .map(|vi| {
+                    vi.labels
+                        .iter()
+                        .map(|label| format!("{:?}", label))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .filter(|s| !s.is_empty());
             RecordSummary {
-                value: format!("({}{}", record.data, value_information),
+                display: format!("({}{}", record.data, value_information_display),
+                value,
+                exponent: value_information.map(|vi| vi.decimal_scale_exponent),
+                unit,
+                quantity,
                 data_information,
                 header_hex: record.data_record_header_hex(),
                 data_hex: record.data_hex(),
@@ -450,20 +482,6 @@ fn summarize_wireless(
 fn build_output<T: serde::Serialize>(parsed: &T, summary: FrameSummary) -> ParsedOutput {
     let mut json = serde_json::to_value(parsed).unwrap_or_default();
     if let serde_json::Value::Object(ref mut map) = json {
-        if let Some(mfr) = &summary.manufacturer {
-            if let (Some(name), Some(website), Some(description)) =
-                (&mfr.name, &mfr.website, &mfr.description)
-            {
-                map.insert(
-                    "manufacturer_info".to_string(),
-                    serde_json::json!({
-                        "name": name,
-                        "website": website,
-                        "description": description,
-                    }),
-                );
-            }
-        }
         map.insert(
             "summary".to_string(),
             serde_json::to_value(&summary).unwrap_or_default(),
@@ -471,16 +489,6 @@ fn build_output<T: serde::Serialize>(parsed: &T, summary: FrameSummary) -> Parse
     }
 
     let mut yaml = serde_yaml::to_string(parsed).unwrap_or_default();
-    if let Some(mfr) = &summary.manufacturer {
-        if let (Some(name), Some(website), Some(description)) =
-            (&mfr.name, &mfr.website, &mfr.description)
-        {
-            yaml.push_str(&format!(
-                "manufacturer_info:\n  name: {}\n  website: {}\n  description: {}\n",
-                name, website, description
-            ));
-        }
-    }
     yaml.push_str(
         &serde_yaml::to_string(&SummarySection { summary: &summary }).unwrap_or_default(),
     );
@@ -694,7 +702,7 @@ fn render_table(summary: &FrameSummary, key_provided: bool) -> String {
         value_table.set_titles(row!["Value", "Data Information", "Header Hex", "Data Hex"]);
         for record in &summary.records {
             value_table.add_row(row![
-                record.value,
+                record.display,
                 record.data_information,
                 record.header_hex,
                 record.data_hex
@@ -776,7 +784,7 @@ pub fn parse_to_csv(input: &str, key: Option<&[u8; 16]>) -> String {
         summary.device_type.clone().unwrap_or_default(),
     ];
     for record in &summary.records {
-        row.push(record.value.clone());
+        row.push(record.display.clone());
         row.push(record.data_information.clone());
     }
     writer
@@ -1535,7 +1543,177 @@ mod tests {
                     );
                 }
             }
+
+            // The structured record fields in the JSON summary must agree with
+            // the normalized summary the table and CSV render from.
+            let parsed: serde_json::Value =
+                serde_json::from_str(&json).expect("json output should be valid");
+            let json_records = parsed
+                .get("summary")
+                .and_then(|s| s.get("records"))
+                .and_then(|r| r.as_array())
+                .expect("json summary should contain records");
+            assert_eq!(json_records.len(), summary.records.len());
+            for (json_record, record) in json_records.iter().zip(&summary.records) {
+                assert_eq!(
+                    json_record.get("display").and_then(|v| v.as_str()),
+                    Some(record.display.as_str()),
+                    "json record display mismatch for input {input}"
+                );
+                assert_eq!(
+                    json_record.get("value").and_then(|v| v.as_f64()),
+                    record.value,
+                    "json record value mismatch for input {input}"
+                );
+                assert_eq!(
+                    json_record
+                        .get("exponent")
+                        .and_then(|v| v.as_i64())
+                        .map(|v| v as isize),
+                    record.exponent,
+                    "json record exponent mismatch for input {input}"
+                );
+                assert_eq!(
+                    json_record.get("unit").and_then(|v| v.as_str()),
+                    record.unit.as_deref(),
+                    "json record unit mismatch for input {input}"
+                );
+                assert_eq!(
+                    json_record.get("quantity").and_then(|v| v.as_str()),
+                    record.quantity.as_deref(),
+                    "json record quantity mismatch for input {input}"
+                );
+                // The display string the table/CSV formats use must embed the
+                // same structured information.
+                if let Some(unit) = &record.unit {
+                    assert!(
+                        record.display.contains(unit.as_str()),
+                        "display {:?} should contain unit {unit:?}",
+                        record.display
+                    );
+                }
+                if let Some(exponent) = record.exponent.filter(|e| *e != 0) {
+                    assert!(
+                        record.display.contains(&format!("e{exponent}")),
+                        "display {:?} should contain exponent {exponent}",
+                        record.display
+                    );
+                }
+            }
         }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_json_records_contain_structured_values() {
+        let input = "68 3D 3D 68 08 01 72 00 51 20 02 82 4D 02 04 00 88 00 00 04 07 00 00 00 00 0C 15 03 00 00 00 0B 2E 00 00 00 0B 3B 00 00 00 0A 5A 88 12 0A 5E 16 05 0B 61 23 77 00 02 6C 8C 11 02 27 37 0D 0F 60 00 67 16";
+        let json_output = super::parse_to_json(input, None);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_output).expect("json output should be valid");
+        let records = parsed
+            .get("summary")
+            .and_then(|s| s.get("records"))
+            .and_then(|r| r.as_array())
+            .expect("summary should contain records");
+
+        // "(3)e-1[m³](Volume)" becomes structured fields.
+        let volume = records
+            .iter()
+            .find(|r| r.get("quantity").and_then(|v| v.as_str()) == Some("Volume"))
+            .expect("volume record");
+        assert_eq!(volume.get("value").and_then(|v| v.as_f64()), Some(3.0));
+        assert_eq!(volume.get("exponent").and_then(|v| v.as_i64()), Some(-1));
+        assert_eq!(volume.get("unit").and_then(|v| v.as_str()), Some("m³"));
+        assert_eq!(
+            volume.get("display").and_then(|v| v.as_str()),
+            Some("(3)e-1[m³](Volume)")
+        );
+
+        // A date record has no numeric value but keeps its display string.
+        let date = records
+            .iter()
+            .find(|r| r.get("quantity").and_then(|v| v.as_str()) == Some("Date"))
+            .expect("date record");
+        assert!(date.get("value").is_none());
+        assert_eq!(
+            date.get("display").and_then(|v| v.as_str()),
+            Some("(12/Jan/12)(Date)")
+        );
+
+        // A manufacturer-specific record has neither value information nor a
+        // numeric value.
+        let manufacturer_specific = records
+            .iter()
+            .find(|r| {
+                r.get("data_information")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| s.contains("ManufacturerSpecific"))
+            })
+            .expect("manufacturer specific record");
+        assert!(manufacturer_specific.get("value").is_none());
+        assert!(manufacturer_specific.get("exponent").is_none());
+        assert!(manufacturer_specific.get("unit").is_none());
+        assert!(manufacturer_specific.get("quantity").is_none());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_json_and_yaml_have_no_manufacturer_info() {
+        let input = "68 3D 3D 68 08 01 72 00 51 20 02 82 4D 02 04 00 88 00 00 04 07 00 00 00 00 0C 15 03 00 00 00 0B 2E 00 00 00 0B 3B 00 00 00 0A 5A 88 12 0A 5E 16 05 0B 61 23 77 00 02 6C 8C 11 02 27 37 0D 0F 60 00 67 16";
+        let json_output = super::parse_to_json(input, None);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_output).expect("json output should be valid");
+        assert!(parsed.get("manufacturer_info").is_none());
+        // summary.manufacturer carries the same information instead.
+        assert_eq!(
+            parsed
+                .get("summary")
+                .and_then(|s| s.get("manufacturer"))
+                .and_then(|m| m.get("name"))
+                .and_then(|v| v.as_str()),
+            Some("Schlumberger Industries")
+        );
+
+        let yaml_output = super::parse_to_yaml(input, None);
+        assert!(!yaml_output.contains("manufacturer_info:"));
+        assert!(yaml_output.contains("name: Schlumberger Industries"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_byte_payloads_serialize_as_hex_strings() {
+        // Wireless frame: frame.data must be a compact uppercase hex string.
+        let wireless_input = "1444AE0C7856341201078C2027780B134365877AC5";
+        let json_output = super::parse_to_json(wireless_input, None);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_output).expect("json output should be valid");
+        let frame_data = parsed
+            .get("frame")
+            .and_then(|f| f.get("data"))
+            .expect("wireless frame should contain data");
+        let hex = frame_data.as_str().expect("frame data should be a string");
+        assert!(!hex.is_empty());
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(hex, hex.to_uppercase());
+
+        // Data records: raw_bytes must be hex strings as well.
+        let wired_input = "68 3D 3D 68 08 01 72 00 51 20 02 82 4D 02 04 00 88 00 00 04 07 00 00 00 00 0C 15 03 00 00 00 0B 2E 00 00 00 0B 3B 00 00 00 0A 5A 88 12 0A 5E 16 05 0B 61 23 77 00 02 6C 8C 11 02 27 37 0D 0F 60 00 67 16";
+        let json_output = super::parse_to_json(wired_input, None);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_output).expect("json output should be valid");
+        let records = parsed
+            .get("data_records")
+            .and_then(|r| r.as_array())
+            .expect("data records");
+        let first_raw_bytes = records
+            .first()
+            .and_then(|r| r.get("raw_bytes"))
+            .and_then(|v| v.as_str())
+            .expect("raw_bytes should be a hex string");
+        assert_eq!(first_raw_bytes, "040700000000");
+
+        // Manufacturer-specific data is a hex string instead of a byte array.
+        assert!(json_output.contains("\"ManufacturerSpecific\": \"6000\""));
     }
 
     #[cfg(feature = "std")]

--- a/tests/test_other_meters.rs
+++ b/tests/test_other_meters.rs
@@ -130,7 +130,7 @@ mod tests {
             0x1F
         );
         assert!(rec["data"]["value"]["ManufacturerSpecific"]
-            .as_array()
+            .as_str()
             .unwrap()
             .is_empty());
     }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser-wasm-pack"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "A wasm-pack to use the library for parsing M-Bus frames"
 license = "MIT"
@@ -22,7 +22,7 @@ decryption = ["m-bus-parser/decryption"]
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-m-bus-parser = { path = "..", version = "0.1.4", features = ["std", "serde"] }
+m-bus-parser = { path = "..", version = "0.2.0", features = ["std", "serde"] }
 serde = { version = "1.0" }
 serde_json = "1.0"
 


### PR DESCRIPTION
Follow-up to #106, implementing the breaking cleanups it deferred. All changes are confined to the serialization layer; the parser API is untouched.

## Changes

**Structured record values.** `summary.records[].value` was a table-style string like `"(2850427)e-2[m³](Volume)"`. It is now split into structured fields derived from the processed data record header:

```json
{
  "display": "(876543)e-3[m³](Volume)",
  "value": 876543.0,
  "exponent": -3,
  "unit": "m³",
  "quantity": "Volume",
  "data_information": "0,Inst,BCD 6-digit",
  "header_hex": "0B 13",
  "data_hex": "43 65 87"
}
```

The human-readable string is kept as `display`, and the table and CSV formats render from it, so their output is byte-for-byte unchanged. `value`, `exponent`, `unit` and `quantity` are omitted where they don't apply (dates, manufacturer-specific records).

**Removed `manufacturer_info`.** The top-level JSON/YAML key duplicated `summary.manufacturer` (code/name/website/description). Migration: read `summary.manufacturer` instead.

**Hex strings for raw byte payloads.** `frame.data` (wireless), `data_records[].raw_bytes` and manufacturer-specific record data now serialize as compact uppercase hex strings (`"2F2F"`) instead of decimal byte arrays (`[47, 47]`). Implemented as serialize-only serde attributes backed by a new `m_bus_core::serde_hex` helper (`no_std`-compatible, `collect_str`-based), so `Deserialize` impls and the parser API are unchanged.

## Versioning

This is a breaking change for JSON/YAML consumers: all workspace crates are bumped in lockstep from 0.1.4 to 0.2.0, and the migration is documented in CHANGELOG.md.

## Verification

- `cargo test --features std,decryption` — 37 passed
- `cargo test --features std` — 34 passed
- `cargo build` (no default features), `cargo check --workspace`, clippy, fmt — clean
- Cross-format agreement test extended to assert the structured record fields match the normalized summary; new tests cover structured values, `manufacturer_info` removal, and hex payload serialization
- Verified end-to-end via the CLI: JSON/YAML show the new shape; table and CSV output unchanged

Note: `cargo check -p m-bus-application-layer --features serde` (without `std`) fails, but this is pre-existing on main and unrelated.