### PR TITLE
Measure ArrayVec vs iterator resources

### DIFF
--- a/.github/workflows/arrayvec-iterator-resources.yml
+++ b/.github/workflows/arrayvec-iterator-resources.yml
@@ -51,7 +51,8 @@ jobs:
         working-directory: experiments/arrayvec-iterator-resources
         run: |
           set -euxo pipefail
-          RUSTFLAGS='-C force-frame-pointers=yes' cargo rustc --release --target thumbv7m-none-eabi --lib -- --emit=obj,asm
+          cargo clean
+          RUSTFLAGS='-C force-frame-pointers=yes -C lto=no -C embed-bitcode=no' cargo rustc --release --target thumbv7m-none-eabi --lib -- --emit=obj,asm
 
           OBJ=$(find target/thumbv7m-none-eabi/release/deps -name 'arrayvec_iterator_resources-*.o' | head -1)
           ASM=$(find target/thumbv7m-none-eabi/release/deps -name 'arrayvec_iterator_resources-*.s' | head -1)
@@ -61,6 +62,8 @@ jobs:
           echo "assembly=$ASM"
           echo '--- Cortex-M target-specific type sizes (symbol byte sizes) ---'
           "$LLVM_BIN/llvm-nm" -S --size-sort "$OBJ" | grep TYPE_SIZE
+          echo '--- Cortex-M type declarations from assembly ---'
+          grep -A4 -B2 'TYPE_SIZE_' "$ASM"
           echo '--- Cortex-M function code sizes (symbol byte sizes) ---'
           "$LLVM_BIN/llvm-nm" -S --size-sort "$OBJ" | grep -E ' (eager_probe|iterator_probe)$'
 

--- a/.github/workflows/arrayvec-iterator-resources.yml
+++ b/.github/workflows/arrayvec-iterator-resources.yml
@@ -1,0 +1,89 @@
+name: ArrayVec vs iterator resource measurement
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'experiments/arrayvec-iterator-resources/**'
+      - '.github/workflows/arrayvec-iterator-resources.yml'
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust targets and LLVM tools
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7m-none-eabi
+          components: llvm-tools-preview
+
+      - name: Compile and test
+        working-directory: experiments/arrayvec-iterator-resources
+        run: |
+          set -euxo pipefail
+          cargo test
+          cargo build --release
+
+      - name: Runtime measurements on x86-64
+        working-directory: experiments/arrayvec-iterator-resources
+        run: |
+          set -euxo pipefail
+          cargo run --release | tee host-measurements.txt
+          echo '--- ELF section sizes ---'
+          size target/release/arrayvec-iterator-resources
+
+      - name: Host function code and stack-frame assembly
+        working-directory: experiments/arrayvec-iterator-resources
+        run: |
+          set -euxo pipefail
+          RUSTFLAGS='-C force-frame-pointers=yes' cargo rustc --release --bin arrayvec-iterator-resources -- --emit=obj
+          BIN=target/release/arrayvec-iterator-resources
+          echo '--- Function symbol sizes (bytes) ---'
+          nm -S --size-sort "$BIN" | grep -E ' (eager_probe|iterator_probe)$'
+          echo '--- eager_probe assembly ---'
+          objdump -d "$BIN" | sed -n '/<eager_probe>:/,/^$/p'
+          echo '--- iterator_probe assembly ---'
+          objdump -d "$BIN" | sed -n '/<iterator_probe>:/,/^$/p'
+
+      - name: Cortex-M no_std measurements
+        working-directory: experiments/arrayvec-iterator-resources
+        run: |
+          set -euxo pipefail
+          RUSTFLAGS='-C force-frame-pointers=yes' cargo rustc --release --target thumbv7m-none-eabi --lib -- --emit=obj,asm
+
+          OBJ=$(find target/thumbv7m-none-eabi/release/deps -name 'arrayvec_iterator_resources-*.o' | head -1)
+          ASM=$(find target/thumbv7m-none-eabi/release/deps -name 'arrayvec_iterator_resources-*.s' | head -1)
+          LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin"
+
+          echo "object=$OBJ"
+          echo "assembly=$ASM"
+          echo '--- Cortex-M target-specific type sizes (symbol byte sizes) ---'
+          "$LLVM_BIN/llvm-nm" -S --size-sort "$OBJ" | grep TYPE_SIZE
+          echo '--- Cortex-M function code sizes (symbol byte sizes) ---'
+          "$LLVM_BIN/llvm-nm" -S --size-sort "$OBJ" | grep -E ' (eager_probe|iterator_probe)$'
+
+          python3 - "$ASM" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          text = pathlib.Path(sys.argv[1]).read_text()
+          for function in ("eager_probe", "iterator_probe"):
+              match = re.search(
+                  rf"(?ms)^\s*{function}:\n(?P<body>.*?)(?=^\.Lfunc_end|^\s*\.size\s+{function})",
+                  text,
+              )
+              print(f"--- {function} Cortex-M prologue / stack instructions ---")
+              if not match:
+                  print("function not found")
+                  continue
+              body = match.group("body")
+              relevant = [
+                  line.strip()
+                  for line in body.splitlines()
+                  if re.search(r"\b(push|pop|sub\s+sp|add\s+sp)\b", line)
+              ]
+              print("\n".join(relevant) if relevant else "no explicit stack adjustment found")
+          PY

--- a/experiments/arrayvec-iterator-resources/Cargo.toml
+++ b/experiments/arrayvec-iterator-resources/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "arrayvec-iterator-resources"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+arrayvec = { version = "0.7.4", default-features = false }
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+
+# Keep this example independent from the parent repository workspace.
+[workspace]

--- a/experiments/arrayvec-iterator-resources/src/lib.rs
+++ b/experiments/arrayvec-iterator-resources/src/lib.rs
@@ -1,0 +1,168 @@
+#![no_std]
+
+use arrayvec::ArrayVec;
+use core::{hint::black_box, mem::size_of};
+
+/// Deliberately mirrors the capacity from the original M-Bus design.
+/// The accepted *values* are still only integers from 1 through 10.
+pub const CAPACITY: usize = 117;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseError {
+    EmptyToken,
+    NotANumber,
+    OutsideOneToTen,
+    TooManyNumbers,
+}
+
+fn parse_one(token: &str) -> Result<u8, ParseError> {
+    if token.is_empty() {
+        return Err(ParseError::EmptyToken);
+    }
+
+    let mut value = 0_u8;
+    for byte in token.bytes() {
+        if !byte.is_ascii_digit() {
+            return Err(ParseError::NotANumber);
+        }
+
+        value = value
+            .checked_mul(10)
+            .and_then(|v| v.checked_add(byte - b'0'))
+            .ok_or(ParseError::NotANumber)?;
+    }
+
+    if (1..=10).contains(&value) {
+        Ok(value)
+    } else {
+        Err(ParseError::OutsideOneToTen)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Eager variant: all numbers are parsed immediately and stored inline.
+// ---------------------------------------------------------------------------
+
+pub type ParsedNumbers = ArrayVec<u8, CAPACITY>;
+
+pub fn parse_arrayvec(input: &str) -> Result<ParsedNumbers, ParseError> {
+    let mut numbers = ParsedNumbers::new();
+
+    for token in input.split_ascii_whitespace() {
+        numbers
+            .try_push(parse_one(token)?)
+            .map_err(|_| ParseError::TooManyNumbers)?;
+    }
+
+    Ok(numbers)
+}
+
+// ---------------------------------------------------------------------------
+// Lazy variant: only a borrowed input slice and its progress are retained.
+// ---------------------------------------------------------------------------
+
+pub struct Numbers<'a> {
+    tokens: core::str::SplitAsciiWhitespace<'a>,
+}
+
+pub fn parse_iter(input: &str) -> Numbers<'_> {
+    Numbers {
+        tokens: input.split_ascii_whitespace(),
+    }
+}
+
+impl Iterator for Numbers<'_> {
+    type Item = Result<u8, ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.tokens.next().map(parse_one)
+    }
+}
+
+// Export symbols whose byte sizes can be inspected in a Cortex-M object file.
+// This lets llvm-nm report target-specific type sizes without executing code.
+#[used]
+#[no_mangle]
+pub static TYPE_SIZE_ARRAYVEC_U8_117: [u8; size_of::<ParsedNumbers>()] =
+    [0; size_of::<ParsedNumbers>()];
+
+#[used]
+#[no_mangle]
+pub static TYPE_SIZE_ITERATOR: [u8; size_of::<Numbers<'static>>()] =
+    [0; size_of::<Numbers<'static>>()];
+
+/// A simplified stand-in for a large decoded protocol record.
+#[repr(C)]
+pub struct DemoRecord {
+    pub bytes: [u8; 280],
+}
+
+pub type DemoRecordBuffer = ArrayVec<DemoRecord, CAPACITY>;
+
+#[used]
+#[no_mangle]
+pub static TYPE_SIZE_DEMO_RECORD_ARRAYVEC: [u8; size_of::<DemoRecordBuffer>()] =
+    [0; size_of::<DemoRecordBuffer>()];
+
+/// Forces the eager result to become a real local object so stack use remains
+/// visible in generated assembly.
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C" fn eager_probe(input: *const u8, len: usize) -> u32 {
+    let bytes = core::slice::from_raw_parts(input, len);
+    let text = core::str::from_utf8_unchecked(bytes);
+
+    let numbers = match parse_arrayvec(text) {
+        Ok(numbers) => numbers,
+        Err(_) => return u32::MAX,
+    };
+
+    black_box(&numbers);
+    numbers.iter().map(|value| u32::from(*value)).sum()
+}
+
+/// Forces the iterator state to become observable while consuming records one
+/// at a time.
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C" fn iterator_probe(input: *const u8, len: usize) -> u32 {
+    let bytes = core::slice::from_raw_parts(input, len);
+    let text = core::str::from_utf8_unchecked(bytes);
+    let mut numbers = parse_iter(text);
+    let mut sum = 0_u32;
+
+    for result in numbers.by_ref() {
+        match result {
+            Ok(value) => sum += u32::from(value),
+            Err(_) => return u32::MAX,
+        }
+    }
+
+    black_box(&numbers);
+    sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_variants_parse_the_same_numbers() {
+        let input = "1 2 3 4 5 6 7 8 9 10";
+        let eager = parse_arrayvec(input).unwrap();
+        let mut lazy = parse_iter(input);
+
+        for expected in eager {
+            assert_eq!(lazy.next(), Some(Ok(expected)));
+        }
+        assert_eq!(lazy.next(), None);
+    }
+
+    #[test]
+    fn invalid_values_are_rejected() {
+        assert_eq!(
+            parse_iter("1 11").nth(1),
+            Some(Err(ParseError::OutsideOneToTen))
+        );
+    }
+}

--- a/experiments/arrayvec-iterator-resources/src/main.rs
+++ b/experiments/arrayvec-iterator-resources/src/main.rs
@@ -1,0 +1,111 @@
+use arrayvec_iterator_resources::{
+    eager_probe, iterator_probe, parse_arrayvec, parse_iter, DemoRecordBuffer, Numbers,
+    ParsedNumbers, CAPACITY,
+};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    hint::black_box,
+    mem::{align_of, size_of},
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Instant,
+};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, old: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(new_size, Ordering::Relaxed);
+        System.realloc(ptr, old, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn allocation_measurement<T>(work: impl FnOnce() -> T) -> (T, usize, usize) {
+    ALLOCATIONS.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    let value = work();
+    let allocations = ALLOCATIONS.load(Ordering::SeqCst);
+    let bytes = ALLOCATED_BYTES.load(Ordering::SeqCst);
+    (value, allocations, bytes)
+}
+
+fn benchmark(name: &str, iterations: u32, mut work: impl FnMut() -> u32) {
+    let start = Instant::now();
+    let mut checksum = 0_u32;
+    for _ in 0..iterations {
+        checksum = checksum.wrapping_add(black_box(work()));
+    }
+    let elapsed = start.elapsed();
+    let nanos_per_parse = elapsed.as_nanos() as f64 / f64::from(iterations);
+    println!(
+        "time.{name}: total={elapsed:?}, iterations={iterations}, ns_per_parse={nanos_per_parse:.1}, checksum={checksum}"
+    );
+}
+
+fn main() {
+    const INPUT: &str = "1 2 3 4 5 6 7 8 9 10";
+
+    println!("target.pointer_width_bits: {}", usize::BITS);
+    println!("capacity: {CAPACITY}");
+    println!(
+        "type.arrayvec: size={} align={}",
+        size_of::<ParsedNumbers>(),
+        align_of::<ParsedNumbers>()
+    );
+    println!(
+        "type.iterator: size={} align={}",
+        size_of::<Numbers<'static>>(),
+        align_of::<Numbers<'static>>()
+    );
+    println!(
+        "type.demo_record_arrayvec: size={} align={}",
+        size_of::<DemoRecordBuffer>(),
+        align_of::<DemoRecordBuffer>()
+    );
+
+    let (eager, eager_allocs, eager_bytes) =
+        allocation_measurement(|| parse_arrayvec(INPUT).unwrap());
+    let (lazy_sum, lazy_allocs, lazy_bytes) = allocation_measurement(|| {
+        parse_iter(INPUT)
+            .map(Result::unwrap)
+            .map(u32::from)
+            .sum::<u32>()
+    });
+
+    println!(
+        "heap.eager: allocations={eager_allocs} requested_bytes={eager_bytes} result_len={}",
+        eager.len()
+    );
+    println!(
+        "heap.iterator: allocations={lazy_allocs} requested_bytes={lazy_bytes} sum={lazy_sum}"
+    );
+
+    let probe_eager = unsafe { eager_probe(INPUT.as_ptr(), INPUT.len()) };
+    let probe_iterator = unsafe { iterator_probe(INPUT.as_ptr(), INPUT.len()) };
+    println!("probe.eager_sum: {probe_eager}");
+    println!("probe.iterator_sum: {probe_iterator}");
+
+    let iterations = 1_000_000;
+    benchmark("eager", iterations, || unsafe {
+        eager_probe(INPUT.as_ptr(), INPUT.len())
+    });
+    benchmark("iterator", iterations, || unsafe {
+        iterator_probe(INPUT.as_ptr(), INPUT.len())
+    });
+}


### PR DESCRIPTION
Temporary measurement PR created to compile the minimal no_std ArrayVec/iterator example and collect real host and Cortex-M resource numbers. This will be closed after the measurements are collected.