### PR TITLE
feat(output): harmonize canonical schema for 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-10
+
 ### Changed
 
 - Simplified canonical record units to a single `unit` string. It contains the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified canonical record units to a single `unit` string. It contains the
+  standardized representation when available, without exposing a technical
+  `ucum` label, and falls back to the human-readable symbol for units without a
+  standard mapping. This change advances the canonical output schema to
+  version 2.
+- Aligned canonical frame functions, record functions, quantities, and data
+  coding names with M-Bus terminology (`RSP_UD`, `Instantaneous value`,
+  `Volume flow`, `6-digit BCD`) across JSON, YAML, CSV, tables, Mermaid, Python,
+  and WebAssembly. Annotation identifiers now use `snake_case`, and standalone
+  application-record decoding now uses the same canonical record contract.
+
 ## [0.4.1]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A library for parsing M-Bus frames"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -222,6 +222,30 @@ An embedded example (Cortex-M) is in [`examples/cortex-m/`](./examples/cortex-m)
 | `annotated`     | `-t annotated`      | Byte-segment annotation envelope |
 | `annotated-text`| `-t annotated-text` | Human-readable byte annotations |
 
+### Naming and interoperability
+
+The canonical JSON, YAML, CSV, table, Mermaid, Python, and WebAssembly outputs
+share one vocabulary:
+
+- JSON/YAML member names and annotation identifiers use `snake_case`.
+- Link-layer functions use the M-Bus mnemonics (`RSP_UD`, `REQ_UD2`,
+  `SND_NKE`). Record functions, quantities, and data codings use the terms from
+  the M-Bus application-layer tables, such as `Instantaneous value`,
+  `Volume flow`, and `6-digit BCD`.
+- `unit` is a single case-sensitive [UCUM](https://ucum.org/ucum) expression
+  when one is available, such as `W`, `Cel`, or `m3.h-1`.
+- Complete temporal values use ISO 8601 notation. The parser does not invent a
+  timezone when a meter does not transmit one.
+- Raw binary values use uppercase hexadecimal and fields containing them end
+  in `_hex`.
+
+There is no common JSON schema shared by M-Bus parsers. These rules retain the
+protocol vocabulary used by [M-Bus](https://m-bus.com/documentation-wired/06-application-layer)
+and libmbus while keeping the structured formats predictable. The `xml` format
+deliberately retains libmbus's established XML vocabulary and unit symbols for
+compatibility. Formats whose names end in `-legacy` retain their historical
+contracts.
+
 ---
 
 ## Protocol Coverage

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A cli to use the library for parsing M-Bus frames"
 license = "MIT"
@@ -22,7 +22,7 @@ default = ["decryption"]
 decryption = ["m-bus-parser/decryption"]
 
 [dependencies]
-m-bus-parser = { path = "..", version = "0.4.1", features = ["std", "serde"] }
+m-bus-parser = { path = "..", version = "0.4.2", features = ["std", "serde"] }
 hex = "0.4"
 clap = { version = "4.5.4", features = ["derive"] }
 terminal_size = "0.4"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymbusparser"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 homepage = "https://maebli.github.io/"
 repository = "https://github.com/maebli/m-bus-parser"
@@ -8,7 +8,7 @@ description = "A Python binding for the M-Bus parser"
 license = "MIT"
 
 [dependencies]
-m-bus-parser = { path = "..", version = "0.4.1", features = ["std", "serde", "decryption"] }
+m-bus-parser = { path = "..", version = "0.4.2", features = ["std", "serde", "decryption"] }
 serde_json = "1.0"
 pyo3 = { version = "0.29.0", features = ["extension-module", "generate-import-lib"] }
 hex = "0.4"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
-use m_bus_parser::user_data::DataRecords;
 use m_bus_parser::{
-    decode_bytes, decode_hex_bytes, render_bytes, render_hex, DecodeOptions, OutputError,
-    OutputFormat, RenderOptions,
+    decode_bytes, decode_data_records, decode_hex_bytes, render_bytes, render_hex, DecodeOptions,
+    OutputError, OutputFormat, RenderOptions,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -62,14 +61,7 @@ fn json_to_python(py: Python<'_>, json: &str) -> PyResult<Py<PyAny>> {
 }
 
 fn records_json(data: &[u8]) -> PyResult<String> {
-    let records = DataRecords::from(data)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| {
-            binding_error(
-                "application.records_invalid",
-                format!("failed to parse application-layer records: {error}"),
-            )
-        })?;
+    let records = decode_data_records(data).map_err(parser_error)?;
 
     serde_json::to_string(&records).map_err(|error| {
         binding_error(

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -27,7 +27,7 @@ class BindingsTests(unittest.TestCase):
         frame_bytes = bytes.fromhex(WIRED_FRAME.replace(" ", ""))
 
         self.assertIsInstance(parsed, dict)
-        self.assertEqual(parsed["schema_version"], 1)
+        self.assertEqual(parsed["schema_version"], 2)
         self.assertEqual(parsed["protocol"], "wired")
         self.assertIn("frame", parsed)
         self.assertEqual(parsed, pymbusparser.parse(frame_bytes))
@@ -53,6 +53,10 @@ class BindingsTests(unittest.TestCase):
 
         self.assertIsInstance(records, list)
         self.assertGreater(len(records), 0)
+        self.assertEqual(records[0]["function"], "Instantaneous value")
+        self.assertIn("quantities", records[0])
+        self.assertIn("data_coding", records[0])
+        self.assertNotIn("data_record_header", records[0])
 
     def test_render_and_legacy_api_return_strings(self):
         rendered = pymbusparser.render(WIRED_FRAME, "json")

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -14,6 +14,7 @@ use wired_mbus_link_layer::WiredFrame;
 /// The protocol role of a byte range within an M-Bus frame.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[non_exhaustive]
 pub enum SegmentKind {
     // Link layer
@@ -93,6 +94,7 @@ impl fmt::Display for SegmentKind {
 /// The protocol layer a segment belongs to.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum Layer {
     Frame,
     AppHeader,
@@ -181,7 +183,10 @@ fn annotate_wired(data: &[u8]) -> Result<Vec<ByteSegment>, MbusError> {
                 start: 1,
                 end: 2,
                 kind: SegmentKind::CField,
-                detail: Cow::Owned(format!("C Field: {}", function)),
+                detail: Cow::Owned(format!(
+                    "C Field: {}",
+                    crate::output::frame_function_name(&function)
+                )),
                 group: None,
                 layer: Layer::Frame,
             });
@@ -299,7 +304,7 @@ fn annotate_long_or_control_frame(
         kind: SegmentKind::CField,
         detail: Cow::Owned(format!(
             "C Field: {}{}",
-            function,
+            crate::output::frame_function_name(function),
             if is_control { " (Control)" } else { "" }
         )),
         group: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,9 @@ pub use wireless_mbus_link_layer::{ManufacturerId, WirelessFrame};
 pub use mbus_data::serialize_mbus_data;
 #[cfg(feature = "std")]
 pub use output::{
-    decode_bytes, decode_hex, decode_hex_bytes, render_bytes, render_hex, DecodeOptions,
-    DecodedOutput, OutputError, OutputFormat, RenderOptions,
+    decode_bytes, decode_data_records, decode_data_records_hex, decode_hex, decode_hex_bytes,
+    render_bytes, render_hex, DecodeOptions, DecodedOutput, OutputError, OutputFormat,
+    RenderOptions,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/mbus_data.rs
+++ b/src/mbus_data.rs
@@ -1224,7 +1224,7 @@ pub(crate) fn render_annotated_bytes(
                 })?;
             replace_encrypted_payload_segments(&mut display_segments, &display_data);
             return serde_json::to_string_pretty(&serde_json::json!({
-                "schema_version": 1,
+                "schema_version": 2,
                 "bytes": display_data,
                 "segments": display_segments,
                 "decrypted": true,
@@ -1244,7 +1244,7 @@ pub(crate) fn render_annotated_bytes(
     let _ = key;
 
     serde_json::to_string_pretty(&serde_json::json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "bytes": data,
         "segments": original_segments,
         "decrypted": false,
@@ -1939,18 +1939,18 @@ mod tests {
             .expect("hexview output should be a JSON array");
 
         assert!(segments.iter().any(|seg| {
-            seg.get("kind").and_then(|v| v.as_str()) == Some("CiField")
+            seg.get("kind").and_then(|v| v.as_str()) == Some("ci_field")
                 && seg
                     .get("detail")
                     .and_then(|v| v.as_str())
                     .is_some_and(|detail| detail.contains("0x78"))
         }));
         assert!(segments.iter().any(|seg| {
-            seg.get("kind").and_then(|v| v.as_str()) == Some("DataPayload")
+            seg.get("kind").and_then(|v| v.as_str()) == Some("data_payload")
                 && seg.get("detail").and_then(|v| v.as_str()) == Some("876543")
         }));
         assert!(!segments.iter().any(|seg| {
-            seg.get("kind").and_then(|v| v.as_str()) == Some("Unknown")
+            seg.get("kind").and_then(|v| v.as_str()) == Some("unknown")
                 || seg
                     .get("detail")
                     .and_then(|v| v.as_str())
@@ -1997,7 +1997,7 @@ mod tests {
             .and_then(|v| v.as_array())
             .expect("decrypted hexview should include annotation segments");
         assert!(segments.iter().any(|seg| {
-            seg.get("kind").and_then(|v| v.as_str()) == Some("DataPayload")
+            seg.get("kind").and_then(|v| v.as_str()) == Some("data_payload")
                 && seg
                     .get("detail")
                     .and_then(|v| v.as_str())
@@ -2006,7 +2006,7 @@ mod tests {
         assert!(
             !segments
                 .iter()
-                .any(|seg| seg.get("kind").and_then(|v| v.as_str()) == Some("EncryptedPayload")),
+                .any(|seg| seg.get("kind").and_then(|v| v.as_str()) == Some("encrypted_payload")),
             "decrypted hexview should annotate decrypted records, not ciphertext payloads"
         );
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -15,10 +15,12 @@ use wireless_mbus_link_layer as wireless;
 
 use crate::mbus_data::MbusData;
 use crate::user_data;
-use crate::user_data::data_information::{DataFieldCoding, DataType, Month, SingleEveryOrInvalid};
-use crate::user_data::value_information::{Unit, UnitName};
+use crate::user_data::data_information::{
+    DataFieldCoding, DataType, FunctionField, Month, SingleEveryOrInvalid, SpecialFunctions,
+};
+use crate::user_data::value_information::{Unit, UnitName, ValueLabel};
 
-const SCHEMA_VERSION: u8 = 1;
+const SCHEMA_VERSION: u8 = 2;
 const DEFAULT_TABLE_WIDTH: usize = 100;
 const MINIMUM_TABLE_WIDTH: usize = 32;
 
@@ -328,8 +330,9 @@ pub struct RecordOutput {
     pub subunit: u64,
     pub quantities: Vec<String>,
     pub value: ValueOutput,
+    /// Standardized unit notation when available, otherwise a readable symbol.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit: Option<UnitOutput>,
+    pub unit: Option<String>,
     pub data_coding: String,
     pub header_hex: String,
     pub data_hex: String,
@@ -357,20 +360,6 @@ pub struct ValueOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<serde_json::Value>,
     pub raw_hex: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct UnitComponent {
-    pub name: String,
-    pub exponent: i32,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct UnitOutput {
-    pub display: String,
-    pub components: Vec<UnitComponent>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ucum: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -485,6 +474,28 @@ pub fn decode_bytes(data: &[u8], options: &DecodeOptions) -> Result<DecodedOutpu
             wireless: format!("{error:?}"),
         }),
     }
+}
+
+/// Decode DIF/VIF records after link and transport headers have been removed.
+pub fn decode_data_records(data: &[u8]) -> Result<Vec<RecordOutput>, OutputError> {
+    if data.is_empty() {
+        return Err(OutputError::EmptyInput);
+    }
+    let records = user_data::DataRecords::from(data);
+    let (output, error) = collect_records(Some(&records));
+    if let Some((offset, message)) = error {
+        return Err(OutputError::Rendering {
+            code: "application.records_invalid",
+            message: format!("failed to parse data record at byte offset {offset}: {message}"),
+        });
+    }
+    Ok(output)
+}
+
+/// Decode human-readable hexadecimal DIF/VIF records.
+pub fn decode_data_records_hex(input: &str) -> Result<Vec<RecordOutput>, OutputError> {
+    let data = decode_hex_bytes(input)?;
+    decode_data_records(&data)
 }
 
 /// Render a human-readable hexadecimal frame.
@@ -838,7 +849,7 @@ fn build_wired_output(
             data,
         } => (
             "long",
-            Some(function.to_string()),
+            Some(frame_function_name(function)),
             Some(address.to_string()),
             Some(*data),
         ),
@@ -848,13 +859,13 @@ fn build_wired_output(
             data,
         } => (
             "control",
-            Some(function.to_string()),
+            Some(frame_function_name(function)),
             Some(address.to_string()),
             Some(*data),
         ),
         wired::WiredFrame::ShortFrame { function, address } => (
             "short",
-            Some(function.to_string()),
+            Some(frame_function_name(function)),
             Some(address.to_string()),
             None,
         ),
@@ -895,7 +906,10 @@ fn build_wireless_output(
         "wireless",
         FrameOutput {
             kind: "wireless".to_string(),
-            function: parsed.frame.function.map(|function| function.to_string()),
+            function: parsed
+                .frame
+                .function
+                .map(|function| frame_function_name(&function)),
             address: None,
             control_field: Some(format!("{:02X}", parsed.frame.control_field)),
         },
@@ -1272,22 +1286,19 @@ fn record_output(index: usize, record: &user_data::DataRecord<'_>) -> RecordOutp
     let information = record.data_information();
     let value_information = record.value_information();
     let function = information
-        .map(|value| value.function_field.to_string())
-        .unwrap_or_else(|| "manufacturer_specific".to_string());
+        .map(|value| match value.data_field_coding {
+            DataFieldCoding::SpecialFunctions(function) => special_function_name(function),
+            _ => record_function_name(value.function_field).to_string(),
+        })
+        .unwrap_or_else(|| special_record_name(record));
     let storage_number = information.map_or(0, |value| value.storage_number);
     let tariff = information.map_or(0, |value| value.tariff);
     let subunit = information.map_or(0, |value| value.device);
     let data_coding = information
-        .map(|value| value.data_field_coding.to_string())
-        .unwrap_or_else(|| "manufacturer specific".to_string());
+        .map(|value| data_coding_name(value.data_field_coding))
+        .unwrap_or_else(|| special_record_name(record));
     let quantities = value_information
-        .map(|value| {
-            value
-                .labels
-                .iter()
-                .map(|label| format!("{label:?}"))
-                .collect()
-        })
+        .map(|value| value.labels.iter().map(quantity_name).collect())
         .unwrap_or_default();
     let unit = value_information
         .and_then(|value| (!value.units.is_empty()).then(|| unit_output(value.units.as_slice())));
@@ -1305,6 +1316,150 @@ fn record_output(index: usize, record: &user_data::DataRecord<'_>) -> RecordOutp
         header_hex: record.data_record_header_hex(),
         data_hex: record.data_hex(),
         record_hex: spaced_hex(record.raw_bytes()),
+    }
+}
+
+pub(crate) fn frame_function_name(function: &m_bus_core::Function) -> String {
+    use m_bus_core::Function;
+
+    match function {
+        Function::SndNk { prm } => format!("SND_NKE (PRM: {prm})"),
+        Function::SndUd { fcb } => format!("SND_UD (FCB: {fcb})"),
+        Function::SndUd2 => "SND_UD2".to_string(),
+        Function::SndUd3 => "SND_UD3".to_string(),
+        Function::SndNr => "SND_NR".to_string(),
+        Function::SendIr => "SND_IR".to_string(),
+        Function::AccNr => "ACC_NR".to_string(),
+        Function::AccDmd => "ACC_DMD".to_string(),
+        Function::ReqUd1 { fcb } => format!("REQ_UD1 (FCB: {fcb})"),
+        Function::ReqUd2 { fcb } => format!("REQ_UD2 (FCB: {fcb})"),
+        Function::RspUd { acd, dfc } => format!("RSP_UD (ACD: {acd}, DFC: {dfc})"),
+        Function::Ack => "ACK".to_string(),
+        Function::Nack => "NACK".to_string(),
+        Function::CnfIr => "CNF_IR".to_string(),
+        _ => format!("{function:?}"),
+    }
+}
+
+const fn record_function_name(function: FunctionField) -> &'static str {
+    match function {
+        FunctionField::InstantaneousValue => "Instantaneous value",
+        FunctionField::MaximumValue => "Maximum value",
+        FunctionField::MinimumValue => "Minimum value",
+        FunctionField::ValueDuringErrorState => "Value during error state",
+        _ => "Unknown",
+    }
+}
+
+fn special_record_name(record: &user_data::DataRecord<'_>) -> String {
+    match record.raw_bytes().first().copied().map(|dif| dif & 0x7F) {
+        Some(0x0F) => "Manufacturer specific".to_string(),
+        Some(0x1F) => "More records follow".to_string(),
+        Some(0x2F) => "Idle filler".to_string(),
+        Some(0x7F) => "Global readout request".to_string(),
+        _ => "Special function".to_string(),
+    }
+}
+
+fn data_coding_name(coding: DataFieldCoding) -> String {
+    match coding {
+        DataFieldCoding::NoData => "No data".to_string(),
+        DataFieldCoding::Integer8Bit => "8-bit integer".to_string(),
+        DataFieldCoding::Integer16Bit => "16-bit integer".to_string(),
+        DataFieldCoding::Integer24Bit => "24-bit integer".to_string(),
+        DataFieldCoding::Integer32Bit => "32-bit integer".to_string(),
+        DataFieldCoding::Real32Bit => "32-bit real".to_string(),
+        DataFieldCoding::Integer48Bit => "48-bit integer".to_string(),
+        DataFieldCoding::Integer64Bit => "64-bit integer".to_string(),
+        DataFieldCoding::SelectionForReadout => "Selection for readout".to_string(),
+        DataFieldCoding::BCD2Digit => "2-digit BCD".to_string(),
+        DataFieldCoding::BCD4Digit => "4-digit BCD".to_string(),
+        DataFieldCoding::BCD6Digit => "6-digit BCD".to_string(),
+        DataFieldCoding::BCD8Digit => "8-digit BCD".to_string(),
+        DataFieldCoding::VariableLength => "Variable length".to_string(),
+        DataFieldCoding::BCDDigit12 => "12-digit BCD".to_string(),
+        DataFieldCoding::DateTypeG => "Date (type G)".to_string(),
+        DataFieldCoding::DateTimeTypeF => "Date and time (type F)".to_string(),
+        DataFieldCoding::DateTimeTypeJ => "Time (type J)".to_string(),
+        DataFieldCoding::DateTimeTypeI => "Date and time (type I)".to_string(),
+        DataFieldCoding::SpecialFunctions(function) => special_function_name(function),
+        _ => "Unknown".to_string(),
+    }
+}
+
+fn special_function_name(function: SpecialFunctions) -> String {
+    match function {
+        SpecialFunctions::ManufacturerSpecific => "Manufacturer specific".to_string(),
+        SpecialFunctions::MoreRecordsFollow => "More records follow".to_string(),
+        SpecialFunctions::IdleFiller => "Idle filler".to_string(),
+        SpecialFunctions::Reserved => "Reserved special function".to_string(),
+        SpecialFunctions::GlobalReadoutRequest => "Global readout request".to_string(),
+        _ => "Unknown special function".to_string(),
+    }
+}
+
+fn quantity_name(label: &ValueLabel) -> String {
+    match label {
+        ValueLabel::Date => "Time point (date)".to_string(),
+        ValueLabel::Time => "Time point (time)".to_string(),
+        ValueLabel::DateTime | ValueLabel::DateTimeWithSeconds => {
+            "Time point (date and time)".to_string()
+        }
+        ValueLabel::DataContainerForWmbusProtocol => {
+            "Data container for wireless M-Bus protocol".to_string()
+        }
+        ValueLabel::PhaseUtoU => "Phase U-to-U".to_string(),
+        ValueLabel::PhaseUtoI => "Phase U-to-I".to_string(),
+        ValueLabel::PhaseItoU => "Phase I-to-U".to_string(),
+        _ => sentence_case_identifier(&format!("{label:?}")),
+    }
+}
+
+fn sentence_case_identifier(identifier: &str) -> String {
+    let characters = identifier.chars().collect::<Vec<_>>();
+    let mut words = Vec::new();
+    let mut word = String::new();
+    for (index, character) in characters.iter().copied().enumerate() {
+        let previous = index.checked_sub(1).and_then(|value| characters.get(value));
+        let next = characters.get(index + 1);
+        let boundary = !word.is_empty()
+            && character.is_ascii_uppercase()
+            && (previous.is_some_and(|value| value.is_ascii_lowercase() || value.is_ascii_digit())
+                || (previous.is_some_and(|value| value.is_ascii_uppercase())
+                    && next.is_some_and(|value| value.is_ascii_lowercase())));
+        if boundary {
+            words.push(word);
+            word = String::new();
+        }
+        word.push(character);
+    }
+    if !word.is_empty() {
+        words.push(word);
+    }
+
+    words
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| standardized_word(&word, index == 0))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn standardized_word(word: &str, first: bool) -> String {
+    match word {
+        "Vif" => "VIF".to_string(),
+        "Vife" => "VIFE".to_string(),
+        "Obis" => "OBIS".to_string(),
+        "Wmbus" => "wireless M-Bus".to_string(),
+        _ if word
+            .chars()
+            .filter(|character| character.is_ascii_alphabetic())
+            .all(|character| character.is_ascii_uppercase()) =>
+        {
+            word.to_string()
+        }
+        _ if first => word.to_string(),
+        _ => word.to_ascii_lowercase(),
     }
 }
 
@@ -1829,25 +1984,13 @@ fn apply_power10(integer: &str, exponent: isize) -> String {
     output
 }
 
-fn unit_output(units: &[Unit]) -> UnitOutput {
+fn unit_output(units: &[Unit]) -> String {
     let display = units.iter().map(ToString::to_string).collect::<String>();
-    let components = units
-        .iter()
-        .map(|unit| UnitComponent {
-            name: format!("{:?}", unit.name),
-            exponent: unit.exponent,
-        })
-        .collect();
-    let ucum = units
+    units
         .iter()
         .map(ucum_component)
         .collect::<Option<Vec<_>>>()
-        .map(|components| components.join("."));
-    UnitOutput {
-        display,
-        components,
-        ucum,
-    }
+        .map_or(display, |components| components.join("."))
 }
 
 fn ucum_component(unit: &Unit) -> Option<String> {
@@ -1901,7 +2044,6 @@ fn render_csv(decoded: &DecodedOutput) -> Result<String, OutputError> {
         "scale_power10",
         "offset_power10",
         "unit",
-        "unit_ucum",
         "data_coding",
         "header_hex",
         "data_hex",
@@ -2044,16 +2186,7 @@ fn csv_record_values(record: &RecordOutput) -> Vec<String> {
             .offset_power10
             .map(|value| value.to_string())
             .unwrap_or_default(),
-        record
-            .unit
-            .as_ref()
-            .map(|value| value.display.clone())
-            .unwrap_or_default(),
-        record
-            .unit
-            .as_ref()
-            .and_then(|value| value.ucum.clone())
-            .unwrap_or_default(),
+        record.unit.clone().unwrap_or_default(),
         record.data_coding.clone(),
         record.header_hex.clone(),
         record.data_hex.clone(),
@@ -2243,7 +2376,7 @@ fn reading(record: &RecordOutput) -> String {
     let unit = record
         .unit
         .as_ref()
-        .map(|value| format!(" {}", value.display))
+        .map(|value| format!(" {value}"))
         .unwrap_or_default();
     format!("{quantity}: {}{unit}", record.value.display)
 }
@@ -2571,10 +2704,54 @@ mod tests {
         let rendered =
             render_hex(WIRED_FRAME, OutputFormat::Json, &RenderOptions::default()).unwrap();
         let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
         assert_eq!(value["protocol"], "wired");
         assert!(value["records"].is_array());
         assert!(value.get("summary").is_none());
+    }
+
+    #[test]
+    fn canonical_units_use_an_unlabelled_standardized_value() {
+        assert_eq!(
+            unit_output(&[
+                Unit {
+                    name: UnitName::Meter,
+                    exponent: 3,
+                },
+                Unit {
+                    name: UnitName::Hour,
+                    exponent: -1,
+                },
+            ]),
+            "m3.h-1"
+        );
+        assert_eq!(
+            unit_output(&[Unit {
+                name: UnitName::ReactiveWatt,
+                exponent: 1,
+            }]),
+            "W (reactive)"
+        );
+    }
+
+    #[test]
+    fn canonical_names_follow_m_bus_terms_and_preserve_acronyms() {
+        assert_eq!(quantity_name(&ValueLabel::VolumeFlow), "Volume flow");
+        assert_eq!(quantity_name(&ValueLabel::RFPowerLevel), "RF power level");
+        assert_eq!(
+            quantity_name(&ValueLabel::ObisDeclaration),
+            "OBIS declaration"
+        );
+    }
+
+    #[test]
+    fn standalone_records_use_the_canonical_record_schema() {
+        let records = decode_data_records(&[0x03, 0x13, 0x15, 0x31, 0x00]).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].function, "Instantaneous value");
+        assert_eq!(records[0].quantities, ["Volume"]);
+        assert_eq!(records[0].unit.as_deref(), Some("m3"));
+        assert_eq!(records[0].data_coding, "24-bit integer");
     }
 
     #[test]

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -38,9 +38,21 @@ fn canonical_json_has_a_versioned_stable_root() {
             "missing canonical field {field}"
         );
     }
-    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["schema_version"], 2);
     assert_eq!(value["protocol"], "wired");
     assert!(!object.contains_key("summary"));
+    assert_eq!(
+        value["frame"]["function"],
+        "RSP_UD (ACD: false, DFC: false)"
+    );
+    assert_eq!(value["records"][2]["function"], "Instantaneous value");
+    assert_eq!(value["records"][3]["quantities"][0], "Volume flow");
+    assert_eq!(value["records"][4]["quantities"][0], "Flow temperature");
+    assert_eq!(value["records"][2]["data_coding"], "6-digit BCD");
+    assert_eq!(value["records"][9]["function"], "Manufacturer specific");
+    assert_eq!(value["records"][2]["unit"], "W");
+    assert!(value["records"][2]["unit"].is_string());
+    assert_eq!(value["records"][3]["unit"], "m3.h-1");
 }
 
 #[test]
@@ -54,7 +66,7 @@ fn enrichment_is_optional_without_changing_the_schema() {
     )
     .unwrap();
     let value = serde_json::to_value(decoded).unwrap();
-    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["schema_version"], 2);
     assert!(value.get("enrichment").is_none());
 }
 
@@ -78,6 +90,14 @@ fn formats_and_compatibility_aliases_share_one_parser() {
         "one input frame must produce one CSV data row"
     );
     assert!(csv.lines().next().unwrap().contains("record_0_value"));
+    assert!(csv.contains("Instantaneous value"));
+    assert!(csv.contains("Volume flow"));
+    assert!(csv.contains("6-digit BCD"));
+
+    let yaml = render_hex(WIRED_FRAME, OutputFormat::Yaml, &RenderOptions::default()).unwrap();
+    let yaml_value: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(yaml_value["records"][3]["quantities"][0], "Volume flow");
+    assert_eq!(yaml_value["records"][3]["unit"], "m3.h-1");
 }
 
 #[test]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m-bus-parser-wasm-pack"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A wasm-pack to use the library for parsing M-Bus frames"
 license = "MIT"
@@ -22,7 +22,7 @@ decryption = ["m-bus-parser/decryption"]
 
 [dependencies]
 wasm-bindgen = "0.2.84"
-m-bus-parser = { path = "..", version = "0.4.1", features = ["std", "serde"] }
+m-bus-parser = { path = "..", version = "0.4.2", features = ["std", "serde"] }
 js-sys = "0.3"
 serde = { version = "1.0" }
 serde_json = "1.0"

--- a/wasm/tests/web.rs
+++ b/wasm/tests/web.rs
@@ -19,7 +19,7 @@ fn test_m_bus_parse_table() {
     let input = "68 3D 3D 68 08 01 72 00 51 20 02 82 4D 02 04 00 88 00 00 04 07 00 00 00 00 0C 15 03 00 00 00 0B 2E 00 00 00 0B 3B 00 00 00 0A 5A 88 12 0A 5E 16 05 0B 61 23 77 00 02 6C 8C 11 02 27 37 0D 0F 60 00 67 16";
     let output = m_bus_parser_wasm_pack::m_bus_parse(input, "table_format");
     assert!(output.contains("wired"));
-    assert!(output.contains("RspUd"));
+    assert!(output.contains("RSP_UD"));
     assert!(output.contains("02205100"));
     assert!(output.lines().all(|line| line.chars().count() <= 100));
 }
@@ -34,7 +34,7 @@ fn decode_returns_a_native_versioned_object() {
         Reflect::get(&decoded, &JsValue::from_str("schema_version"))
             .unwrap()
             .as_f64(),
-        Some(1.0)
+        Some(2.0)
     );
     assert_eq!(
         Reflect::get(&decoded, &JsValue::from_str("protocol"))
@@ -60,18 +60,18 @@ fn test_m_bus_parse_hexview_ci_78_annotations() {
         .expect("hexview should return a canonical annotation envelope");
 
     assert!(segments.iter().any(|seg| {
-        seg.get("kind").and_then(|v| v.as_str()) == Some("CiField")
+        seg.get("kind").and_then(|v| v.as_str()) == Some("ci_field")
             && seg
                 .get("detail")
                 .and_then(|v| v.as_str())
                 .is_some_and(|detail| detail.contains("0x78"))
     }));
     assert!(segments.iter().any(|seg| {
-        seg.get("kind").and_then(|v| v.as_str()) == Some("DataPayload")
+        seg.get("kind").and_then(|v| v.as_str()) == Some("data_payload")
             && seg.get("detail").and_then(|v| v.as_str()) == Some("876543")
     }));
     assert!(!segments.iter().any(|seg| {
-        seg.get("kind").and_then(|v| v.as_str()) == Some("Unknown")
+        seg.get("kind").and_then(|v| v.as_str()) == Some("unknown")
             || seg
                 .get("detail")
                 .and_then(|v| v.as_str())
@@ -106,7 +106,7 @@ fn test_m_bus_parse_hexview_with_key_displays_decrypted_payload() {
         .and_then(|v| v.as_array())
         .expect("decrypted hexview should include annotation segments");
     assert!(segments.iter().any(|seg| {
-        seg.get("kind").and_then(|v| v.as_str()) == Some("DataPayload")
+        seg.get("kind").and_then(|v| v.as_str()) == Some("data_payload")
             && seg
                 .get("detail")
                 .and_then(|v| v.as_str())
@@ -114,7 +114,7 @@ fn test_m_bus_parse_hexview_with_key_displays_decrypted_payload() {
     }));
     assert!(!segments
         .iter()
-        .any(|seg| seg.get("kind").and_then(|v| v.as_str()) == Some("EncryptedPayload")));
+        .any(|seg| seg.get("kind").and_then(|v| v.as_str()) == Some("encrypted_payload")));
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

- advance canonical output to schema version 2
- standardize frame functions, record functions, quantities, data coding names, and unit strings across Rust, Python, WebAssembly, JSON, YAML, CSV, tables, Mermaid, and annotations
- expose standalone DIF/VIF record decoding through the canonical record contract
- serialize annotation identifiers as `snake_case`
- document the naming and interoperability contract
- prepare Rust, CLI, Python, and WASM package metadata for release `0.4.2`

## Why

Output surfaces previously relied on a mixture of Rust `Debug`/`Display` representations and binding-specific record serialization. Units were represented as a nested object with both display and UCUM fields, while standalone Python record decoding returned a different structure from complete-frame decoding. This made equivalent data differ by output format and runtime.

## Impact

Canonical structured output now uses schema version 2. The `unit` field is a single standardized string when a mapping is available, with a readable fallback otherwise. Legacy compatibility formats and the libmbus-compatible XML vocabulary remain unchanged.

Release tags `v0.4.2`, `cli-v0.4.2`, `python-v0.4.2`, and `wasm-v0.4.2` will publish the package set. The WASM release also rebuilds and commits the website artifacts under `docs/`.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --all-features -- -D warnings`
- Python extension API tests: 7 passed
- headless Firefox WASM tests: 8 passed
- `cargo fmt --all -- --check`
- `git diff --check`